### PR TITLE
Enable both Qloop and Kloop

### DIFF
--- a/csrc/flash_attn_rocm/src/fmha_dgrad_fp16_bf16_kernel.gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/fmha_dgrad_fp16_bf16_kernel.gfx90a.cpp
@@ -12,7 +12,7 @@
 // specific prior written permission. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
 // HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
 // INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-// FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE+
 // COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
 // INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
 // LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
@@ -243,9 +243,9 @@ void run_fmha_dgrad_fp16_bf16_gfx90a_loop_(LaunchParams<FmhaDgradParams> &launch
           AccDataType, ShuffleDataType, QkvElementOp, QkvElementOp, Scale,
           QkvElementOp, YElementOp, GemmSpec, TensorSpecQ, TensorSpecK,
           TensorSpecV, TensorSpecY, 1, 256,
-          128,         // MPerBlock
+          64,          // MPerBlock
           128,         // NPerBlock
-          64,          // KPerBlock
+          128,          // KPerBlock
           128,         // Gemm1NPerBlock
           32,          // Gemm1KPerBlock
           8,           // AK1
@@ -253,10 +253,10 @@ void run_fmha_dgrad_fp16_bf16_gfx90a_loop_(LaunchParams<FmhaDgradParams> &launch
           2,           // B1K1
           32,          // MPerXDL
           32,          // NPerXDL
-          1,           // MXdlPerWave
-          4,           // NXdlPerWave
+          2,           // MXdlPerWave
+          1,           // NXdlPerWave
           4,           // Gemm1NXdlPerWave
-          2,           // Gemm2NXdlPerWave
+          1,           // Gemm2NXdlPerWave
           S<4, 64, 1>, // ABlockTransfer
           S<1, 0, 2>, S<1, 0, 2>, 2, 8, 8, true,
           S<4, 64, 1>, // BBlockTransfer
@@ -279,7 +279,7 @@ void run_fmha_dgrad_fp16_bf16_gfx90a_loop_(LaunchParams<FmhaDgradParams> &launch
           AccDataType, ShuffleDataType, QkvElementOp, QkvElementOp, Scale,
           QkvElementOp, YElementOp, GemmSpec, TensorSpecQ, TensorSpecK,
           TensorSpecV, TensorSpecY, 1, 256,
-          128,         // MPerBlock
+          64,         // MPerBlock
           128,         // NPerBlock
           64,          // KPerBlock
           64,          // Gemm1NPerBlock
@@ -289,16 +289,14 @@ void run_fmha_dgrad_fp16_bf16_gfx90a_loop_(LaunchParams<FmhaDgradParams> &launch
           2,           // B1K1
           32,          // MPerXDL
           32,          // NPerXDL
-          1,           // MXdlPerWave
-          4,           // NXdlPerWave
+          2,           // MXdlPerWave
+          1,           // NXdlPerWave
           2,           // Gemm1NXdlPerWave
-          2,           // Gemm2NXdlPerWave
+          1,           // Gemm2NXdlPerWave
           S<4, 64, 1>, // ABlockTransfer
           S<1, 0, 2>, S<1, 0, 2>, 2, 8, 8, true,
           S<4, 64, 1>, // BBlockTransfer
           S<1, 0, 2>, S<1, 0, 2>, 2, 8, 8, true,
-          S<8, 32, 1>, // B1BlockTransfer
-          S<0, 2, 1>, S<0, 2, 1>, 1, 4, 2, false,
           1, // CShuffleMXdlPerWavePerShuffle
           2, // CShuffleNXdlPerWavePerShuffle
           S<1, 32, 1, 8>, // CShuffleBlockTransferClusterLengths_MBlock_MPerBlock_NBlock_NPerBlock
@@ -325,16 +323,14 @@ void run_fmha_dgrad_fp16_bf16_gfx90a_loop_(LaunchParams<FmhaDgradParams> &launch
           2,           // B1K1
           32,          // MPerXDL
           32,          // NPerXDL
-          1,           // MXdlPerWave
-          4,           // NXdlPerWave
+          4,           // MXdlPerWave
+          1,           // NXdlPerWave
           1,           // Gemm1NXdlPerWave
           1,           // Gemm2NXdlPerWave
           S<4, 64, 1>, // ABlockTransfer
           S<1, 0, 2>, S<1, 0, 2>, 2, 8, 8, true,
           S<4, 64, 1>, // BBlockTransfer
           S<1, 0, 2>, S<1, 0, 2>, 2, 8, 8, true,
-          S<8, 32, 1>, // B1BlockTransfer
-          S<0, 2, 1>, S<0, 2, 1>, 1, 4, 2, false,
           1, // CShuffleMXdlPerWavePerShuffle
           1, // CShuffleNXdlPerWavePerShuffle
           S<1, 64, 1, 4>, // CShuffleBlockTransferClusterLengths_MBlock_MPerBlock_NBlock_NPerBlock
@@ -354,9 +350,9 @@ void run_fmha_dgrad_fp16_bf16_gfx90a_loop_(LaunchParams<FmhaDgradParams> &launch
           AccDataType, ShuffleDataType, QkvElementOp, QkvElementOp, Scale,
           QkvElementOp, YElementOp, GemmSpec, TensorSpecQ, TensorSpecK,
           TensorSpecV, TensorSpecY, 1, 256,
-          128,         // MPerBlock
+          64,          // MPerBlock
           128,         // NPerBlock
-          64,          // KPerBlock
+          128,          // KPerBlock
           128,         // Gemm1NPerBlock
           32,          // Gemm1KPerBlock
           8,           // AK1
@@ -364,10 +360,10 @@ void run_fmha_dgrad_fp16_bf16_gfx90a_loop_(LaunchParams<FmhaDgradParams> &launch
           2,           // B1K1
           32,          // MPerXDL
           32,          // NPerXDL
-          1,           // MXdlPerWave
-          4,           // NXdlPerWave
+          2,           // MXdlPerWave
+          1,           // NXdlPerWave
           4,           // Gemm1NXdlPerWave
-          2,           // Gemm2NXdlPerWave
+          1,           // Gemm2NXdlPerWave
           S<4, 64, 1>, // ABlockTransfer
           S<1, 0, 2>, S<1, 0, 2>, 2, 8, 8, true,
           S<4, 64, 1>, // BBlockTransfer
@@ -390,7 +386,7 @@ void run_fmha_dgrad_fp16_bf16_gfx90a_loop_(LaunchParams<FmhaDgradParams> &launch
           AccDataType, ShuffleDataType, QkvElementOp, QkvElementOp, Scale,
           QkvElementOp, YElementOp, GemmSpec, TensorSpecQ, TensorSpecK,
           TensorSpecV, TensorSpecY, 1, 256,
-          128,         // MPerBlock
+          64,         // MPerBlock
           128,         // NPerBlock
           64,          // KPerBlock
           64,          // Gemm1NPerBlock
@@ -400,16 +396,14 @@ void run_fmha_dgrad_fp16_bf16_gfx90a_loop_(LaunchParams<FmhaDgradParams> &launch
           2,           // B1K1
           32,          // MPerXDL
           32,          // NPerXDL
-          1,           // MXdlPerWave
-          4,           // NXdlPerWave
+          2,           // MXdlPerWave
+          1,           // NXdlPerWave
           2,           // Gemm1NXdlPerWave
-          2,           // Gemm2NXdlPerWave
+          1,           // Gemm2NXdlPerWave
           S<4, 64, 1>, // ABlockTransfer
           S<1, 0, 2>, S<1, 0, 2>, 2, 8, 8, true,
           S<4, 64, 1>, // BBlockTransfer
           S<1, 0, 2>, S<1, 0, 2>, 2, 8, 8, true,
-          S<8, 32, 1>, // B1BlockTransfer
-          S<0, 2, 1>, S<0, 2, 1>, 1, 4, 2, false,
           1, // CShuffleMXdlPerWavePerShuffle
           2, // CShuffleNXdlPerWavePerShuffle
           S<1, 32, 1, 8>, // CShuffleBlockTransferClusterLengths_MBlock_MPerBlock_NBlock_NPerBlock
@@ -436,16 +430,14 @@ void run_fmha_dgrad_fp16_bf16_gfx90a_loop_(LaunchParams<FmhaDgradParams> &launch
           2,           // B1K1
           32,          // MPerXDL
           32,          // NPerXDL
-          1,           // MXdlPerWave
-          4,           // NXdlPerWave
+          4,           // MXdlPerWave
+          1,           // NXdlPerWave
           1,           // Gemm1NXdlPerWave
           1,           // Gemm2NXdlPerWave
           S<4, 64, 1>, // ABlockTransfer
           S<1, 0, 2>, S<1, 0, 2>, 2, 8, 8, true,
           S<4, 64, 1>, // BBlockTransfer
           S<1, 0, 2>, S<1, 0, 2>, 2, 8, 8, true,
-          S<8, 32, 1>, // B1BlockTransfer
-          S<0, 2, 1>, S<0, 2, 1>, 1, 4, 2, false,
           1, // CShuffleMXdlPerWavePerShuffle
           1, // CShuffleNXdlPerWavePerShuffle
           S<1, 64, 1, 4>, // CShuffleBlockTransferClusterLengths_MBlock_MPerBlock_NBlock_NPerBlock
@@ -469,19 +461,19 @@ void run_fmha_dgrad_fp16_bf16_gfx90a(LaunchParams<FmhaDgradParams> &launch_param
     if (launch_params.params.is_bf16) {
       if (launch_params.params.is_causal) {
         if (launch_params.params.d > 64) {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, BFloat16, Int32, BFloat16, 1, 8, kMaskingSpecializationCausal>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, BFloat16, Int16, BFloat16, 1, 8, kMaskingSpecializationCausal>(launch_params);
         } else if (launch_params.params.d > 32) {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, BFloat16, Int32, BFloat16, 2, 8, kMaskingSpecializationCausal>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, BFloat16, Int16, BFloat16, 2, 8, kMaskingSpecializationCausal>(launch_params);
         } else {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, BFloat16, Int32, BFloat16, 3, 8, kMaskingSpecializationCausal>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, BFloat16, Int16, BFloat16, 3, 8, kMaskingSpecializationCausal>(launch_params);
         }
       } else {
         if (launch_params.params.d > 64) {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, BFloat16, Int32, BFloat16, 1, 8, kMaskingSpecializationDefault>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, BFloat16, Int16, BFloat16, 1, 8, kMaskingSpecializationDefault>(launch_params);
         } else if (launch_params.params.d > 32) {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, BFloat16, Int32, BFloat16, 2, 8, kMaskingSpecializationDefault>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, BFloat16, Int16, BFloat16, 2, 8, kMaskingSpecializationDefault>(launch_params);
         } else {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, BFloat16, Int32, BFloat16, 3, 8, kMaskingSpecializationDefault>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, BFloat16, Int16, BFloat16, 3, 8, kMaskingSpecializationDefault>(launch_params);
         }
       }
     } 
@@ -509,19 +501,19 @@ void run_fmha_dgrad_fp16_bf16_gfx90a(LaunchParams<FmhaDgradParams> &launch_param
     if (launch_params.params.is_bf16) {
       if (launch_params.params.is_causal) {
         if (launch_params.params.d > 64) {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int32, BFloat16, 1, 4, kMaskingSpecializationCausal>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int16, BFloat16, 1, 4, kMaskingSpecializationCausal>(launch_params);
         } else if (launch_params.params.d > 32) {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int32, BFloat16, 2, 4, kMaskingSpecializationCausal>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int16, BFloat16, 2, 4, kMaskingSpecializationCausal>(launch_params);
         } else {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int32, BFloat16, 3, 4, kMaskingSpecializationCausal>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int16, BFloat16, 3, 4, kMaskingSpecializationCausal>(launch_params);
         }
       } else {
         if (launch_params.params.d > 64) {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int32, BFloat16, 1, 4, kMaskingSpecializationDefault>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int16, BFloat16, 1, 4, kMaskingSpecializationDefault>(launch_params);
         } else if (launch_params.params.d > 32) {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int32, BFloat16, 2, 4, kMaskingSpecializationDefault>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int16, BFloat16, 2, 4, kMaskingSpecializationDefault>(launch_params);
         } else {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int32, BFloat16, 3, 4, kMaskingSpecializationDefault>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int16, BFloat16, 3, 4, kMaskingSpecializationDefault>(launch_params);
         }
       }
     } else {

--- a/csrc/flash_attn_rocm/src/fmha_dgrad_fp16_bf16_kernel.gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/fmha_dgrad_fp16_bf16_kernel.gfx90a.cpp
@@ -480,19 +480,19 @@ void run_fmha_dgrad_fp16_bf16_gfx90a(LaunchParams<FmhaDgradParams> &launch_param
     else {
       if (launch_params.params.is_causal) {
         if (launch_params.params.d > 64) {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, BFloat16, 1, 8, kMaskingSpecializationCausal>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, Float16, 1, 8, kMaskingSpecializationCausal>(launch_params);
         } else if (launch_params.params.d > 32) {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, BFloat16, 2, 8, kMaskingSpecializationCausal>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, Float16, 2, 8, kMaskingSpecializationCausal>(launch_params);
         } else {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, BFloat16, 3, 8, kMaskingSpecializationCausal>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, Float16, 3, 8, kMaskingSpecializationCausal>(launch_params);
         }
       } else {
         if (launch_params.params.d > 64) {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, BFloat16, 1, 8, kMaskingSpecializationDefault>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, Float16, 1, 8, kMaskingSpecializationDefault>(launch_params);
         } else if (launch_params.params.d > 32) {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, BFloat16, 2, 8, kMaskingSpecializationDefault>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, Float16, 2, 8, kMaskingSpecializationDefault>(launch_params);
         } else {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, BFloat16, 3, 8, kMaskingSpecializationDefault>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, Float16, 3, 8, kMaskingSpecializationDefault>(launch_params);
         }
       }
     }
@@ -501,19 +501,19 @@ void run_fmha_dgrad_fp16_bf16_gfx90a(LaunchParams<FmhaDgradParams> &launch_param
     if (launch_params.params.is_bf16) {
       if (launch_params.params.is_causal) {
         if (launch_params.params.d > 64) {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int16, BFloat16, 1, 4, kMaskingSpecializationCausal>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int32, BFloat16, 1, 4, kMaskingSpecializationCausal>(launch_params);
         } else if (launch_params.params.d > 32) {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int16, BFloat16, 2, 4, kMaskingSpecializationCausal>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int32, BFloat16, 2, 4, kMaskingSpecializationCausal>(launch_params);
         } else {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int16, BFloat16, 3, 4, kMaskingSpecializationCausal>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int32, BFloat16, 3, 4, kMaskingSpecializationCausal>(launch_params);
         }
       } else {
         if (launch_params.params.d > 64) {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int16, BFloat16, 1, 4, kMaskingSpecializationDefault>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int32, BFloat16, 1, 4, kMaskingSpecializationDefault>(launch_params);
         } else if (launch_params.params.d > 32) {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int16, BFloat16, 2, 4, kMaskingSpecializationDefault>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int32, BFloat16, 2, 4, kMaskingSpecializationDefault>(launch_params);
         } else {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int16, BFloat16, 3, 4, kMaskingSpecializationDefault>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<BFloat16, Float32, Int32, BFloat16, 3, 4, kMaskingSpecializationDefault>(launch_params);
         }
       }
     } else {

--- a/csrc/flash_attn_rocm/src/fmha_dgrad_fp16_bf16_kernel.gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/fmha_dgrad_fp16_bf16_kernel.gfx90a.cpp
@@ -480,19 +480,19 @@ void run_fmha_dgrad_fp16_bf16_gfx90a(LaunchParams<FmhaDgradParams> &launch_param
     else {
       if (launch_params.params.is_causal) {
         if (launch_params.params.d > 64) {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, Float16, 1, 8, kMaskingSpecializationCausal>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, BFloat16, 1, 8, kMaskingSpecializationCausal>(launch_params);
         } else if (launch_params.params.d > 32) {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, Float16, 2, 8, kMaskingSpecializationCausal>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, BFloat16, 2, 8, kMaskingSpecializationCausal>(launch_params);
         } else {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, Float16, 3, 8, kMaskingSpecializationCausal>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, BFloat16, 3, 8, kMaskingSpecializationCausal>(launch_params);
         }
       } else {
         if (launch_params.params.d > 64) {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, Float16, 1, 8, kMaskingSpecializationDefault>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, BFloat16, 1, 8, kMaskingSpecializationDefault>(launch_params);
         } else if (launch_params.params.d > 32) {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, Float16, 2, 8, kMaskingSpecializationDefault>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, BFloat16, 2, 8, kMaskingSpecializationDefault>(launch_params);
         } else {
-          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, Float16, 3, 8, kMaskingSpecializationDefault>(launch_params);
+          run_fmha_dgrad_fp16_bf16_gfx90a_loop_<Float16, Float16, Int16, BFloat16, 3, 8, kMaskingSpecializationDefault>(launch_params);
         }
       }
     }

--- a/csrc/flash_attn_rocm/src/fmha_dgrad_fp16_bf16_kernel.gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/fmha_dgrad_fp16_bf16_kernel.gfx90a.cpp
@@ -237,7 +237,7 @@ void run_fmha_dgrad_fp16_bf16_gfx90a_loop_(LaunchParams<FmhaDgradParams> &launch
   if (is_deterministic) {
     if (version == 1) {
       using DeviceGemmInstance = ck::tensor_operation::device::
-        DeviceGroupedMultiheadAttentionBackward_Xdl_CShuffle_V2<
+        DeviceGroupedMultiheadAttentionBackward_Qloop_Xdl_CShuffle_V2<
           NumDimG, NumDimM, NumDimN, NumDimK, NumDimO, InputDataType, OutputDataType, GemmDataType,
           ZDataType, LSEDataType, Acc0BiasDataType, Acc1BiasDataType,
           AccDataType, ShuffleDataType, QkvElementOp, QkvElementOp, Scale,
@@ -273,7 +273,7 @@ void run_fmha_dgrad_fp16_bf16_gfx90a_loop_(LaunchParams<FmhaDgradParams> &launch
       run_kernel(gemm);
     } else if (version == 2) {
       using DeviceGemmInstance = ck::tensor_operation::device::
-        DeviceGroupedMultiheadAttentionBackward_Xdl_CShuffle_V1<
+        DeviceGroupedMultiheadAttentionBackward_Qloop_Xdl_CShuffle_V1<
           NumDimG, NumDimM, NumDimN, NumDimK, NumDimO, InputDataType, OutputDataType, GemmDataType,
           ZDataType, LSEDataType, Acc0BiasDataType, Acc1BiasDataType,
           AccDataType, ShuffleDataType, QkvElementOp, QkvElementOp, Scale,
@@ -307,7 +307,7 @@ void run_fmha_dgrad_fp16_bf16_gfx90a_loop_(LaunchParams<FmhaDgradParams> &launch
       run_kernel(gemm);
     } else {
       using DeviceGemmInstance = ck::tensor_operation::device::
-        DeviceGroupedMultiheadAttentionBackward_Xdl_CShuffle_V1<
+        DeviceGroupedMultiheadAttentionBackward_Qloop_Xdl_CShuffle_V1<
           NumDimG, NumDimM, NumDimN, NumDimK, NumDimO, InputDataType, OutputDataType, GemmDataType,
           ZDataType, LSEDataType, Acc0BiasDataType, Acc1BiasDataType,
           AccDataType, ShuffleDataType, QkvElementOp, QkvElementOp, Scale,
@@ -344,7 +344,7 @@ void run_fmha_dgrad_fp16_bf16_gfx90a_loop_(LaunchParams<FmhaDgradParams> &launch
   } else {
     if (version == 1) {
       using DeviceGemmInstance = ck::tensor_operation::device::
-        DeviceGroupedMultiheadAttentionBackward_Xdl_CShuffle_V2<
+        DeviceGroupedMultiheadAttentionBackward_Qloop_Xdl_CShuffle_V2<
           NumDimG, NumDimM, NumDimN, NumDimK, NumDimO, InputDataType, OutputDataType, GemmDataType,
           ZDataType, LSEDataType, Acc0BiasDataType, Acc1BiasDataType,
           AccDataType, ShuffleDataType, QkvElementOp, QkvElementOp, Scale,
@@ -380,7 +380,7 @@ void run_fmha_dgrad_fp16_bf16_gfx90a_loop_(LaunchParams<FmhaDgradParams> &launch
       run_kernel(gemm);
     } else if (version == 2) {
       using DeviceGemmInstance = ck::tensor_operation::device::
-        DeviceGroupedMultiheadAttentionBackward_Xdl_CShuffle_V1<
+        DeviceGroupedMultiheadAttentionBackward_Qloop_Xdl_CShuffle_V1<
           NumDimG, NumDimM, NumDimN, NumDimK, NumDimO, InputDataType, OutputDataType, GemmDataType,
           ZDataType, LSEDataType, Acc0BiasDataType, Acc1BiasDataType,
           AccDataType, ShuffleDataType, QkvElementOp, QkvElementOp, Scale,
@@ -414,7 +414,7 @@ void run_fmha_dgrad_fp16_bf16_gfx90a_loop_(LaunchParams<FmhaDgradParams> &launch
       run_kernel(gemm);
     } else {
       using DeviceGemmInstance = ck::tensor_operation::device::
-        DeviceGroupedMultiheadAttentionBackward_Xdl_CShuffle_V1<
+        DeviceGroupedMultiheadAttentionBackward_Qloop_Xdl_CShuffle_V1<
           NumDimG, NumDimM, NumDimN, NumDimK, NumDimO, InputDataType, OutputDataType, GemmDataType,
           ZDataType, LSEDataType, Acc0BiasDataType, Acc1BiasDataType,
           AccDataType, ShuffleDataType, QkvElementOp, QkvElementOp, Scale,

--- a/csrc/flash_attn_rocm/src/fmha_fprop_fp16_bf16_kernel.gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/fmha_fprop_fp16_bf16_kernel.gfx90a.cpp
@@ -89,7 +89,7 @@ void run_fmha_fp16_bf16_gfx90a_loop_(LaunchParams<FmhaFpropParams> &launch_param
 
     //init the instance with parameters
     using DeviceGemmInstance1 =
-        ck::tensor_operation::device::DeviceGroupedMultiheadAttentionForward_Xdl_CShuffle<
+        ck::tensor_operation::device::DeviceGroupedMultiheadAttentionForward_Xdl_CShuffle_V2<
             NumDimG,
             NumDimM,
             NumDimN,
@@ -160,7 +160,7 @@ void run_fmha_fp16_bf16_gfx90a_loop_(LaunchParams<FmhaFpropParams> &launch_param
             deterministic>;                       // MaskingSpecialization
 
     using DeviceGemmInstance2 =
-        ck::tensor_operation::device::DeviceGroupedMultiheadAttentionForward_Xdl_CShuffle<
+        ck::tensor_operation::device::DeviceGroupedMultiheadAttentionForward_Xdl_CShuffle_V2<
             NumDimG,
             NumDimM,
             NumDimN,

--- a/csrc/flash_attn_rocm/src/fmha_fprop_fp16_bf16_kernel.gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/fmha_fprop_fp16_bf16_kernel.gfx90a.cpp
@@ -87,6 +87,7 @@ void run_fmha_fp16_bf16_gfx90a_loop_(LaunchParams<FmhaFpropParams> &launch_param
     
     bool is_deterministic = launch_params.params.is_deterministic;
 
+#if USE_QLOOP
     //init the instance with parameters
     using DeviceGemmInstance1 =
         ck::tensor_operation::device::DeviceGroupedMultiheadAttentionForward_Xdl_CShuffle_V2<
@@ -229,7 +230,153 @@ void run_fmha_fp16_bf16_gfx90a_loop_(LaunchParams<FmhaFpropParams> &launch_param
             8,                                    // CShuffleBlockTransferScalarPerVector_NPerBlock
             MaskingSpec,
             nondeterministic>;                       // MaskingSpecialization
-        
+
+#else 
+    //init the instance with parameters
+    using DeviceGemmInstance1 =
+        ck::tensor_operation::device::DeviceGroupedMultiheadAttentionForward_Xdl_CShuffle_V1<
+            NumDimG,
+            NumDimM,
+            NumDimN,
+            NumDimK,
+            NumDimO,
+            ADataType,
+            B0DataType,
+            B1DataType,
+            CDataType,
+            GemmDataType,
+            ZDataType,
+            LSEDataType,
+            Acc0BiasDataType,
+            Acc1BiasDataType,
+            AccDataType,
+            CShuffleDataType,
+            AElementOp,
+            B0ElementOp,
+            Acc0ElementOp,
+            B1ElementOp,
+            CElementOp,
+            GemmSpec,
+            TensorSpecA,
+            TensorSpecB0,
+            TensorSpecB1,
+            TensorSpecC,
+            1,
+            256,
+            MPerBlock,         // MPerBlock
+            NPerBlock,         // NPerBlock
+            KPerBlock,         // KPerBlock
+            Gemm1NPerBlock,    // Gemm1NPerBlock
+            Gemm1KPerBlock,    // Gemm1KPerBlock
+            8,                 // AK1
+            8,                 // BK1
+            2,                 // B1K1
+            MPerXDL,           // MPerXDL
+            NPerXDL,           // NPerXDL
+            1,                 // MXdlPerWave
+            NXdlPerWave,       // NXdlPerWave
+            Gemm1NXdlPerWave,  // Gemm1NXdlPerWave
+            ABlockTransfer,    // ABlockTransfer
+            S<1, 0, 2>,
+            S<1, 0, 2>,
+            2,
+            8,
+            8,
+            ABlockLdsExtraM,   // ABlockLdsExtraM
+            BBlockTransfer,    // BBlockTransfer
+            S<1, 0, 2>,
+            S<1, 0, 2>,
+            2,
+            8,
+            8,
+            B0BlockLdsExtraN,  // B0BlockLdsExtraN
+            B1BlockTransfer,   // B1BlockTransfer
+            S<0, 2, 1>,
+            S<0, 2, 1>,
+            1,
+            B1BlockTransferSrcScalarPerVector,    //B1BlockTransferSrcScalarPerVector
+            2,
+            false,
+            1,                                    // CShuffleMXdlPerWavePerShuffle
+            CShuffleNXdlPerWavePerShuffle,        // CShuffleNXdlPerWavePerShuffle
+            CShuffleBlockTransferClusterLengths,  // CShuffleBlockTransferClusterLengths_MBlock_MPerBlock_NBlock_NPerBlock
+            8,                                    // CShuffleBlockTransferScalarPerVector_NPerBlock
+            MaskingSpec,
+            deterministic>;                       // MaskingSpecialization
+
+    using DeviceGemmInstance2 =
+        ck::tensor_operation::device::DeviceGroupedMultiheadAttentionForward_Xdl_CShuffle_V1<
+            NumDimG,
+            NumDimM,
+            NumDimN,
+            NumDimK,
+            NumDimO,
+            ADataType,
+            B0DataType,
+            B1DataType,
+            CDataType,
+            GemmDataType,
+            ZDataType,
+            LSEDataType,
+            Acc0BiasDataType,
+            Acc1BiasDataType,
+            AccDataType,
+            CShuffleDataType,
+            AElementOp,
+            B0ElementOp,
+            Acc0ElementOp,
+            B1ElementOp,
+            CElementOp,
+            GemmSpec,
+            TensorSpecA,
+            TensorSpecB0,
+            TensorSpecB1,
+            TensorSpecC,
+            1,
+            256,
+            MPerBlock,         // MPerBlock
+            NPerBlock,         // NPerBlock
+            KPerBlock,         // KPerBlock
+            Gemm1NPerBlock,    // Gemm1NPerBlock
+            Gemm1KPerBlock,    // Gemm1KPerBlock
+            8,                 // AK1
+            8,                 // BK1
+            2,                 // B1K1
+            MPerXDL,           // MPerXDL
+            NPerXDL,           // NPerXDL
+            1,                 // MXdlPerWave
+            NXdlPerWave,       // NXdlPerWave
+            Gemm1NXdlPerWave,  // Gemm1NXdlPerWave
+            ABlockTransfer,    // ABlockTransfer
+            S<1, 0, 2>,
+            S<1, 0, 2>,
+            2,
+            8,
+            8,
+            ABlockLdsExtraM,   // ABlockLdsExtraM
+            BBlockTransfer,    // BBlockTransfer
+            S<1, 0, 2>,
+            S<1, 0, 2>,
+            2,
+            8,
+            8,
+            B0BlockLdsExtraN,  // B0BlockLdsExtraN
+            B1BlockTransfer,   // B1BlockTransfer
+            S<0, 2, 1>,
+            S<0, 2, 1>,
+            1,
+            B1BlockTransferSrcScalarPerVector,    //B1BlockTransferSrcScalarPerVector
+            2,
+            false,
+            1,                                    // CShuffleMXdlPerWavePerShuffle
+            CShuffleNXdlPerWavePerShuffle,        // CShuffleNXdlPerWavePerShuffle
+            CShuffleBlockTransferClusterLengths,  // CShuffleBlockTransferClusterLengths_MBlock_MPerBlock_NBlock_NPerBlock
+            8,                                    // CShuffleBlockTransferScalarPerVector_NPerBlock
+            MaskingSpec,
+            nondeterministic>;                       // MaskingSpecialization
+
+#endif
+
     bool time_kernel    = false;
 
     bool input_permute = true;

--- a/csrc/flash_attn_rocm/src/fmha_utils.h
+++ b/csrc/flash_attn_rocm/src/fmha_utils.h
@@ -18,9 +18,19 @@
 
 #include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
 #include "ck/tensor_operation/gpu/device/tensor_specialization.hpp"
+
+#if USE_QLOOP
+//qloop head files
 #include "ck/tensor_operation/gpu/device/impl/device_grouped_mha_bwd_xdl_cshuffle_qloop_v1.hpp"
 #include "ck/tensor_operation/gpu/device/impl/device_grouped_mha_bwd_xdl_cshuffle_qloop_v2.hpp"
 #include "ck/tensor_operation/gpu/device/impl/device_grouped_mha_fwd_xdl_cshuffle_v2.hpp"
+#else
+//kloop head files
+#include "ck/tensor_operation/gpu/device/impl/device_grouped_mha_bwd_xdl_cshuffle_kloop_v1.hpp"
+#include "ck/tensor_operation/gpu/device/impl/device_grouped_mha_bwd_xdl_cshuffle_kloop_v2.hpp"
+#include "ck/tensor_operation/gpu/device/impl/device_grouped_mha_fwd_xdl_cshuffle_v1.hpp"
+#endif
+
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
 #include "ck/library/utility/check_err.hpp"

--- a/csrc/flash_attn_rocm/src/fmha_utils.h
+++ b/csrc/flash_attn_rocm/src/fmha_utils.h
@@ -18,9 +18,9 @@
 
 #include "ck/tensor_operation/gpu/device/gemm_specialization.hpp"
 #include "ck/tensor_operation/gpu/device/tensor_specialization.hpp"
-#include "ck/tensor_operation/gpu/device/impl/device_grouped_multihead_attention_backward_xdl_cshuffle_v1.hpp"
-#include "ck/tensor_operation/gpu/device/impl/device_grouped_multihead_attention_backward_xdl_cshuffle_v2.hpp"
-#include "ck/tensor_operation/gpu/device/impl/device_grouped_multihead_attention_forward_xdl_cshuffle.hpp"
+#include "ck/tensor_operation/gpu/device/impl/device_grouped_mha_bwd_xdl_cshuffle_qloop_v1.hpp"
+#include "ck/tensor_operation/gpu/device/impl/device_grouped_mha_bwd_xdl_cshuffle_qloop_v2.hpp"
+#include "ck/tensor_operation/gpu/device/impl/device_grouped_mha_fwd_xdl_cshuffle_v2.hpp"
 #include "ck/tensor_operation/gpu/element/element_wise_operation.hpp"
 
 #include "ck/library/utility/check_err.hpp"

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ if os.path.exists(os.path.join(torch_dir, "include", "ATen", "CUDAGeneratorImpl.
 
 # raise_if_cuda_home_none("flash_attn")
 # # Check, if CUDA11 is installed for compute capability 8.0
-cc_flag = ["-DBUILD_PYTHON_PACKAGE", f"-DFLASH_ATTENTION_INTERNAL_USE_RTZ={os.environ.get('FLASH_ATTENTION_INTERNAL_USE_RTZ', 1)}"]
+cc_flag = ["-DBUILD_PYTHON_PACKAGE", f"-DFLASH_ATTENTION_INTERNAL_USE_RTZ={os.environ.get('FLASH_ATTENTION_INTERNAL_USE_RTZ', 1)}", f"-DUSE_QLOOP={os.environ.get('USE_QLOOP', 1)}"]
 # _, bare_metal_major, _ = get_cuda_bare_metal_version(CUDA_HOME)
 # if int(bare_metal_major) < 11:
 #     raise RuntimeError("FlashAttention is only supported on CUDA 11")


### PR DESCRIPTION
In this PR, both Qloop and Kloop are enabled. You can choose the branch by using environment parameter USE_QLOOP. If USE_QLOOP=1, then qloop is used. if USE_QLOOP=0, then kloop is used. In the setup.py file, we use USE_QLOOP=1 by default.
Here is a table of performance comparision between Qloop and Kloop.

[kloop.vs.qloop.xlsx](https://github.com/ROCmSoftwarePlatform/flash-attention/files/12025765/kloop.vs.qloop.xlsx)

(In this table, RTZ is used and we choosed function ' flash_attn_unpadded_func ' for test)
From the table, we can find that when comparing total performance (fwd + bwd), qloop is better in most cases. But when comparing fwd only, kloop is better. So we recommend that use kloop for inference, and use qloop for training.
