### PR TITLE
Optimization based on profiling for forward

### DIFF
--- a/csrc/flash_attn_rocm/fmha_api.cpp
+++ b/csrc/flash_attn_rocm/fmha_api.cpp
@@ -89,7 +89,7 @@ void set_params_fprop(FlashFwdParams &params,
     else if(!params.is_mnko_padding && d <= 64){
         params.is_mnko_padding = ((d % 64)==0 ? false : true);
     }
-    else if(!!params.is_mnko_padding && d <= 128){
+    else if(!params.is_mnko_padding && d <= 128){
         params.is_mnko_padding = ((d % 128)==0 ? false : true);
     }
     else{

--- a/csrc/flash_attn_rocm/fmha_api.cpp
+++ b/csrc/flash_attn_rocm/fmha_api.cpp
@@ -83,6 +83,19 @@ void set_params_fprop(FlashFwdParams &params,
     params.d = d;                 // head_dim
     params.is_mnko_padding = false;    // MNKOpadding
 
+    if(!params.is_mnko_padding && d <= 32){
+        params.is_mnko_padding = ((d % 32)==0 ? false : true);
+    }
+    else if(!params.is_mnko_padding && d <= 64){
+        params.is_mnko_padding = ((d % 64)==0 ? false : true);
+    }
+    else if(!!params.is_mnko_padding && d <= 128){
+        params.is_mnko_padding = ((d % 128)==0 ? false : true);
+    }
+    else{
+        std::cout << "Unsupported head dimension" << std::endl;
+    }
+
     if(cu_seqlens_q.device().type() == c10::kCUDA){
         params.host_seqlens_q = std::vector<int>(params.b+1);
         params.host_seqlens_k = std::vector<int>(params.b+1);
@@ -106,6 +119,17 @@ void set_params_fprop(FlashFwdParams &params,
         int temp_q_stride = get_size_in_bytes(d * h * temp_seqlen_q, data_type);
         int temp_seqlen_k = params.host_seqlens_k[i+1] - params.host_seqlens_k[i];
         int temp_k_stride = get_size_in_bytes(d * h * temp_seqlen_k, data_type);
+
+        if(!params.is_mnko_padding && d <= 32){
+            params.is_mnko_padding = ((temp_seqlen_q % 128)==0 && (temp_seqlen_k % 128)==0 ? false : true);
+        }
+        else if(!params.is_mnko_padding && d <= 64){
+            params.is_mnko_padding = ((temp_seqlen_q % 128)==0 && (temp_seqlen_k % 128)==0 ? false : true);
+        }
+        else if(!params.is_mnko_padding && d <= 128){
+            params.is_mnko_padding = ((temp_seqlen_q % 128)==0 && (temp_seqlen_k % 128)==0 ? false : true);
+        }
+
         if(q.is_contiguous()){
             params.q_ptr.push_back(reinterpret_cast<void*>(q_ptr));
             q_ptr = q_ptr + temp_q_stride;

--- a/csrc/flash_attn_rocm/src/device_gemm_trait.h
+++ b/csrc/flash_attn_rocm/src/device_gemm_trait.h
@@ -54,11 +54,14 @@ template <ck::index_t... Is>
 using S = ck::Sequence<Is...>;
 
 static constexpr bool kDeterministic = true;
-static constexpr bool kNonDeterministic = false;       
+static constexpr bool kNonDeterministic = false;
+static constexpr auto kGemmSpecDefault = GemmSpec::Default;
+static constexpr auto kGemmSpecPadding = GemmSpec::MNKOPadding;
 static constexpr auto kMaskingSpecDefault = MaskingSpec::MaskDisabled;                                        
 static constexpr auto kMaskingSpecCausal = MaskingSpec::MaskOutUpperTriangle;
 
 template <typename InputDataType_,
+          GemmSpec kGemmSpec_,
           MaskingSpec kMaskingSpec_,
           bool kIsDeterministic_>
 struct Forward {
@@ -85,7 +88,7 @@ struct Forward {
   static constexpr Index kNumDimK = 1;
   static constexpr Index kNumDimO = 1;
 
-  static constexpr auto kGemmSpec = GemmSpec::MNKOPadding;
+  static constexpr auto kGemmSpec = kGemmSpec_;
 
   static constexpr auto kTensorSpecA  = TensorSpec::Default;
   static constexpr auto kTensorSpecB0 = TensorSpec::Default;

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_gfx90a.h
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_gfx90a.h
@@ -40,7 +40,7 @@ class FlashFwdRunner {
       is_performance_mode_(launch_params.params.is_performance_mode) {}
  
   template <bool kIsQLoop, int kHeadDim, typename T, bool kIsCausal, bool kIsPadding>
-  void Run();
+  void Run(bool is_dropout);
  
  private:
   template <template <typename> typename DeviceGemmTemplate,

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_gfx90a.h
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_gfx90a.h
@@ -39,17 +39,19 @@ class FlashFwdRunner {
       is_deterministic_(launch_params.params.is_deterministic),
       is_performance_mode_(launch_params.params.is_performance_mode) {}
  
-  template <bool kIsQLoop, int kHeadDim, typename T, bool kIsCausal>
+  template <bool kIsQLoop, int kHeadDim, typename T, bool kIsCausal, bool kIsPadding>
   void Run();
  
  private:
   template <template <typename> typename DeviceGemmTemplate,
             typename T, 
+            device_gemm_trait::GemmSpec kGemmSpec,
             device_gemm_trait::MaskingSpec kMaskingSpec, 
             bool kIsDeterministic>
   void run_() {
     // input, output, gemm, dropout, cshuffle, masking specialization, deterministic
     using DeviceGemmTraits = device_gemm_trait::Forward<T,
+                                                        kGemmSpec,
                                                         kMaskingSpec, 
                                                         kIsDeterministic>;
     using DeviceGemmInstance = DeviceGemmInstanceLauncher<DeviceGemmTemplate, DeviceGemmTraits>;

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_bf16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_bf16_causal_gfx90a.cpp
@@ -36,13 +36,13 @@ void FlashFwdRunner::Run<false, 128, device_gemm_trait::BFloat16, true, true>(bo
   });
 } // FlashFwdRunner::Run()
 
-// hdim 128, bf16, causal, MNKO-padding
+// hdim 128, bf16, causal, non-padding
 template <>
 void FlashFwdRunner::Run<false, 128, device_gemm_trait::BFloat16, true, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim128,
                   device_gemm_trait::BFloat16, 
-                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kGemmSpecDefault,
                   device_gemm_trait::kMaskingSpecCausal,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_bf16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_bf16_causal_gfx90a.cpp
@@ -26,7 +26,7 @@
 namespace fwd_device_gemm {
 // hdim 128, bf16, causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<false, 128, device_gemm_trait::BFloat16, true, true>() {
+void FlashFwdRunner::Run<false, 128, device_gemm_trait::BFloat16, true, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim128,
                   device_gemm_trait::BFloat16, 
@@ -38,7 +38,7 @@ void FlashFwdRunner::Run<false, 128, device_gemm_trait::BFloat16, true, true>() 
 
 // hdim 128, bf16, causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<false, 128, device_gemm_trait::BFloat16, true, false>() {
+void FlashFwdRunner::Run<false, 128, device_gemm_trait::BFloat16, true, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim128,
                   device_gemm_trait::BFloat16, 

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_bf16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_bf16_causal_gfx90a.cpp
@@ -24,12 +24,25 @@
 #include "flash_fwd_runner_gfx90a.h"
 
 namespace fwd_device_gemm {
-// hdim 128, bf16, causal
+// hdim 128, bf16, causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<false, 128, device_gemm_trait::BFloat16, true>() {
+void FlashFwdRunner::Run<false, 128, device_gemm_trait::BFloat16, true, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim128,
                   device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kMaskingSpecCausal,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
+// hdim 128, bf16, causal, MNKO-padding
+template <>
+void FlashFwdRunner::Run<false, 128, device_gemm_trait::BFloat16, true, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmKLoopHeadDim128,
+                  device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecPadding,
                   device_gemm_trait::kMaskingSpecCausal,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_bf16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_bf16_noncausal_gfx90a.cpp
@@ -24,12 +24,25 @@
 #include "flash_fwd_runner_gfx90a.h"
 
 namespace fwd_device_gemm {
-// hdim 128, bf16, non-causal
+// hdim 128, bf16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<false, 128, device_gemm_trait::BFloat16, false>() {
+void FlashFwdRunner::Run<false, 128, device_gemm_trait::BFloat16, false, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim128,
                   device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kMaskingSpecDefault,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
+// hdim 128, bf16, non-causal, MNKO-padding
+template <>
+void FlashFwdRunner::Run<false, 128, device_gemm_trait::BFloat16, false, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmKLoopHeadDim128,
+                  device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecPadding,
                   device_gemm_trait::kMaskingSpecDefault,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_bf16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_bf16_noncausal_gfx90a.cpp
@@ -36,13 +36,13 @@ void FlashFwdRunner::Run<false, 128, device_gemm_trait::BFloat16, false, true>(b
   });
 } // FlashFwdRunner::Run()
 
-// hdim 128, bf16, non-causal, MNKO-padding
+// hdim 128, bf16, non-causal, non-padding
 template <>
 void FlashFwdRunner::Run<false, 128, device_gemm_trait::BFloat16, false, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim128,
                   device_gemm_trait::BFloat16, 
-                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kGemmSpecDefault,
                   device_gemm_trait::kMaskingSpecDefault,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_bf16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_bf16_noncausal_gfx90a.cpp
@@ -26,7 +26,7 @@
 namespace fwd_device_gemm {
 // hdim 128, bf16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<false, 128, device_gemm_trait::BFloat16, false, true>() {
+void FlashFwdRunner::Run<false, 128, device_gemm_trait::BFloat16, false, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim128,
                   device_gemm_trait::BFloat16, 
@@ -38,7 +38,7 @@ void FlashFwdRunner::Run<false, 128, device_gemm_trait::BFloat16, false, true>()
 
 // hdim 128, bf16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<false, 128, device_gemm_trait::BFloat16, false, false>() {
+void FlashFwdRunner::Run<false, 128, device_gemm_trait::BFloat16, false, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim128,
                   device_gemm_trait::BFloat16, 

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_fp16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_fp16_causal_gfx90a.cpp
@@ -26,7 +26,7 @@
 namespace fwd_device_gemm {
 // hdim 128, fp16, causal
 template <>
-void FlashFwdRunner::Run<false, 128, device_gemm_trait::Float16, true, true>() {
+void FlashFwdRunner::Run<false, 128, device_gemm_trait::Float16, true, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim128,
                   device_gemm_trait::Float16, 
@@ -38,7 +38,7 @@ void FlashFwdRunner::Run<false, 128, device_gemm_trait::Float16, true, true>() {
 
 // hdim 128, fp16, causal
 template <>
-void FlashFwdRunner::Run<false, 128, device_gemm_trait::Float16, true, false>() {
+void FlashFwdRunner::Run<false, 128, device_gemm_trait::Float16, true, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim128,
                   device_gemm_trait::Float16, 

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_fp16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_fp16_causal_gfx90a.cpp
@@ -26,10 +26,23 @@
 namespace fwd_device_gemm {
 // hdim 128, fp16, causal
 template <>
-void FlashFwdRunner::Run<false, 128, device_gemm_trait::Float16, true>() {
+void FlashFwdRunner::Run<false, 128, device_gemm_trait::Float16, true, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim128,
                   device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kMaskingSpecCausal,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
+// hdim 128, fp16, causal
+template <>
+void FlashFwdRunner::Run<false, 128, device_gemm_trait::Float16, true, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmKLoopHeadDim128,
+                  device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecPadding,
                   device_gemm_trait::kMaskingSpecCausal,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_fp16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_fp16_causal_gfx90a.cpp
@@ -24,7 +24,7 @@
 #include "flash_fwd_runner_gfx90a.h"
 
 namespace fwd_device_gemm {
-// hdim 128, fp16, causal
+// hdim 128, fp16, causal, MNKO-padding
 template <>
 void FlashFwdRunner::Run<false, 128, device_gemm_trait::Float16, true, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
@@ -36,13 +36,13 @@ void FlashFwdRunner::Run<false, 128, device_gemm_trait::Float16, true, true>(boo
   });
 } // FlashFwdRunner::Run()
 
-// hdim 128, fp16, causal
+// hdim 128, fp16, causal, non-padding
 template <>
 void FlashFwdRunner::Run<false, 128, device_gemm_trait::Float16, true, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim128,
                   device_gemm_trait::Float16, 
-                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kGemmSpecDefault,
                   device_gemm_trait::kMaskingSpecCausal,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_fp16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_fp16_noncausal_gfx90a.cpp
@@ -24,7 +24,7 @@
 #include "flash_fwd_runner_gfx90a.h"
 
 namespace fwd_device_gemm {
-// hdim 128, fp16, non-causal
+// hdim 128, fp16, non-causal, MNKO-padding
 template <>
 void FlashFwdRunner::Run<false, 128, device_gemm_trait::Float16, false, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
@@ -36,13 +36,13 @@ void FlashFwdRunner::Run<false, 128, device_gemm_trait::Float16, false, true>(bo
   });
 } // FlashFwdRunner::Run()
 
-// hdim 128, fp16, non-causal
+// hdim 128, fp16, non-causal, non-padding
 template <>
 void FlashFwdRunner::Run<false, 128, device_gemm_trait::Float16, false, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim128,
                   device_gemm_trait::Float16, 
-                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kGemmSpecDefault,
                   device_gemm_trait::kMaskingSpecDefault,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_fp16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_fp16_noncausal_gfx90a.cpp
@@ -26,10 +26,23 @@
 namespace fwd_device_gemm {
 // hdim 128, fp16, non-causal
 template <>
-void FlashFwdRunner::Run<false, 128, device_gemm_trait::Float16, false>() {
+void FlashFwdRunner::Run<false, 128, device_gemm_trait::Float16, false, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim128,
                   device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kMaskingSpecDefault,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
+// hdim 128, fp16, non-causal
+template <>
+void FlashFwdRunner::Run<false, 128, device_gemm_trait::Float16, false, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmKLoopHeadDim128,
+                  device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecPadding,
                   device_gemm_trait::kMaskingSpecDefault,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_fp16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim128_fp16_noncausal_gfx90a.cpp
@@ -26,7 +26,7 @@
 namespace fwd_device_gemm {
 // hdim 128, fp16, non-causal
 template <>
-void FlashFwdRunner::Run<false, 128, device_gemm_trait::Float16, false, true>() {
+void FlashFwdRunner::Run<false, 128, device_gemm_trait::Float16, false, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim128,
                   device_gemm_trait::Float16, 
@@ -38,7 +38,7 @@ void FlashFwdRunner::Run<false, 128, device_gemm_trait::Float16, false, true>() 
 
 // hdim 128, fp16, non-causal
 template <>
-void FlashFwdRunner::Run<false, 128, device_gemm_trait::Float16, false, false>() {
+void FlashFwdRunner::Run<false, 128, device_gemm_trait::Float16, false, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim128,
                   device_gemm_trait::Float16, 

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_bf16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_bf16_causal_gfx90a.cpp
@@ -26,7 +26,7 @@
 namespace fwd_device_gemm {
 // hdim 32, bf16, causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<false, 32, device_gemm_trait::BFloat16, true, true>() {
+void FlashFwdRunner::Run<false, 32, device_gemm_trait::BFloat16, true, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim32,
                   device_gemm_trait::BFloat16, 
@@ -38,7 +38,7 @@ void FlashFwdRunner::Run<false, 32, device_gemm_trait::BFloat16, true, true>() {
 
 // hdim 32, bf16, causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<false, 32, device_gemm_trait::BFloat16, true, false>() {
+void FlashFwdRunner::Run<false, 32, device_gemm_trait::BFloat16, true, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim32,
                   device_gemm_trait::BFloat16, 

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_bf16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_bf16_causal_gfx90a.cpp
@@ -36,13 +36,13 @@ void FlashFwdRunner::Run<false, 32, device_gemm_trait::BFloat16, true, true>(boo
   });
 } // FlashFwdRunner::Run()
 
-// hdim 32, bf16, causal, MNKO-padding
+// hdim 32, bf16, causal, non-padding
 template <>
 void FlashFwdRunner::Run<false, 32, device_gemm_trait::BFloat16, true, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim32,
                   device_gemm_trait::BFloat16, 
-                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kGemmSpecDefault,
                   device_gemm_trait::kMaskingSpecCausal,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_bf16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_bf16_causal_gfx90a.cpp
@@ -24,12 +24,25 @@
 #include "flash_fwd_runner_gfx90a.h"
 
 namespace fwd_device_gemm {
-// hdim 32, bf16, causal
+// hdim 32, bf16, causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<false, 32, device_gemm_trait::BFloat16, true>() {
+void FlashFwdRunner::Run<false, 32, device_gemm_trait::BFloat16, true, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim32,
                   device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kMaskingSpecCausal,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
+// hdim 32, bf16, causal, MNKO-padding
+template <>
+void FlashFwdRunner::Run<false, 32, device_gemm_trait::BFloat16, true, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmKLoopHeadDim32,
+                  device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecPadding,
                   device_gemm_trait::kMaskingSpecCausal,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_bf16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_bf16_noncausal_gfx90a.cpp
@@ -26,7 +26,7 @@
 namespace fwd_device_gemm {
 // hdim 32, bf16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<false, 32, device_gemm_trait::BFloat16, false, true>() {
+void FlashFwdRunner::Run<false, 32, device_gemm_trait::BFloat16, false, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim32,
                   device_gemm_trait::BFloat16, 
@@ -38,7 +38,7 @@ void FlashFwdRunner::Run<false, 32, device_gemm_trait::BFloat16, false, true>() 
 
 // hdim 32, bf16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<false, 32, device_gemm_trait::BFloat16, false, false>() {
+void FlashFwdRunner::Run<false, 32, device_gemm_trait::BFloat16, false, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim32,
                   device_gemm_trait::BFloat16, 

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_bf16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_bf16_noncausal_gfx90a.cpp
@@ -36,13 +36,13 @@ void FlashFwdRunner::Run<false, 32, device_gemm_trait::BFloat16, false, true>(bo
   });
 } // FlashFwdRunner::Run()
 
-// hdim 32, bf16, non-causal, MNKO-padding
+// hdim 32, bf16, non-causal, non-padding
 template <>
 void FlashFwdRunner::Run<false, 32, device_gemm_trait::BFloat16, false, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim32,
                   device_gemm_trait::BFloat16, 
-                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kGemmSpecDefault,
                   device_gemm_trait::kMaskingSpecDefault,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_bf16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_bf16_noncausal_gfx90a.cpp
@@ -24,12 +24,25 @@
 #include "flash_fwd_runner_gfx90a.h"
 
 namespace fwd_device_gemm {
-// hdim 32, bf16, non-causal
+// hdim 32, bf16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<false, 32, device_gemm_trait::BFloat16, false>() {
+void FlashFwdRunner::Run<false, 32, device_gemm_trait::BFloat16, false, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim32,
                   device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kMaskingSpecDefault,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
+// hdim 32, bf16, non-causal, MNKO-padding
+template <>
+void FlashFwdRunner::Run<false, 32, device_gemm_trait::BFloat16, false, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmKLoopHeadDim32,
+                  device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecPadding,
                   device_gemm_trait::kMaskingSpecDefault,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_fp16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_fp16_causal_gfx90a.cpp
@@ -24,12 +24,25 @@
 #include "flash_fwd_runner_gfx90a.h"
 
 namespace fwd_device_gemm {
-// hdim 32, fp16, causal
+// hdim 32, fp16, causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<false, 32, device_gemm_trait::Float16, true>() {
+void FlashFwdRunner::Run<false, 32, device_gemm_trait::Float16, true, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim32,
                   device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kMaskingSpecCausal,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
+// hdim 32, fp16, causal, MNKO-padding
+template <>
+void FlashFwdRunner::Run<false, 32, device_gemm_trait::Float16, true, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmKLoopHeadDim32,
+                  device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecPadding,
                   device_gemm_trait::kMaskingSpecCausal,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_fp16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_fp16_causal_gfx90a.cpp
@@ -36,13 +36,13 @@ void FlashFwdRunner::Run<false, 32, device_gemm_trait::Float16, true, true>(bool
   });
 } // FlashFwdRunner::Run()
 
-// hdim 32, fp16, causal, MNKO-padding
+// hdim 32, fp16, causal, non-padding
 template <>
 void FlashFwdRunner::Run<false, 32, device_gemm_trait::Float16, true, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim32,
                   device_gemm_trait::Float16, 
-                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kGemmSpecDefault,
                   device_gemm_trait::kMaskingSpecCausal,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_fp16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_fp16_causal_gfx90a.cpp
@@ -26,7 +26,7 @@
 namespace fwd_device_gemm {
 // hdim 32, fp16, causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<false, 32, device_gemm_trait::Float16, true, true>() {
+void FlashFwdRunner::Run<false, 32, device_gemm_trait::Float16, true, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim32,
                   device_gemm_trait::Float16, 
@@ -38,7 +38,7 @@ void FlashFwdRunner::Run<false, 32, device_gemm_trait::Float16, true, true>() {
 
 // hdim 32, fp16, causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<false, 32, device_gemm_trait::Float16, true, false>() {
+void FlashFwdRunner::Run<false, 32, device_gemm_trait::Float16, true, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim32,
                   device_gemm_trait::Float16, 

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_fp16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_fp16_noncausal_gfx90a.cpp
@@ -26,7 +26,7 @@
 namespace fwd_device_gemm {
 // hdim 32, fp16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<false, 32, device_gemm_trait::Float16, false, true>() {
+void FlashFwdRunner::Run<false, 32, device_gemm_trait::Float16, false, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim32,
                   device_gemm_trait::Float16, 
@@ -38,7 +38,7 @@ void FlashFwdRunner::Run<false, 32, device_gemm_trait::Float16, false, true>() {
 
 // hdim 32, fp16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<false, 32, device_gemm_trait::Float16, false, false>() {
+void FlashFwdRunner::Run<false, 32, device_gemm_trait::Float16, false, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim32,
                   device_gemm_trait::Float16, 

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_fp16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_fp16_noncausal_gfx90a.cpp
@@ -36,13 +36,13 @@ void FlashFwdRunner::Run<false, 32, device_gemm_trait::Float16, false, true>(boo
   });
 } // FlashFwdRunner::Run()
 
-// hdim 32, fp16, non-causal, MNKO-padding
+// hdim 32, fp16, non-causal, non-padding
 template <>
 void FlashFwdRunner::Run<false, 32, device_gemm_trait::Float16, false, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim32,
                   device_gemm_trait::Float16, 
-                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kGemmSpecDefault,
                   device_gemm_trait::kMaskingSpecDefault,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_fp16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim32_fp16_noncausal_gfx90a.cpp
@@ -24,12 +24,25 @@
 #include "flash_fwd_runner_gfx90a.h"
 
 namespace fwd_device_gemm {
-// hdim 32, fp16, non-causal
+// hdim 32, fp16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<false, 32, device_gemm_trait::Float16, false>() {
+void FlashFwdRunner::Run<false, 32, device_gemm_trait::Float16, false, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim32,
                   device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kMaskingSpecDefault,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
+// hdim 32, fp16, non-causal, MNKO-padding
+template <>
+void FlashFwdRunner::Run<false, 32, device_gemm_trait::Float16, false, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmKLoopHeadDim32,
+                  device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecPadding,
                   device_gemm_trait::kMaskingSpecDefault,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_bf16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_bf16_causal_gfx90a.cpp
@@ -26,7 +26,7 @@
 namespace fwd_device_gemm {
 // hdim 64, bf16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<false, 64, device_gemm_trait::BFloat16, true, true>() {
+void FlashFwdRunner::Run<false, 64, device_gemm_trait::BFloat16, true, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim64,
                   device_gemm_trait::BFloat16, 
@@ -38,7 +38,7 @@ void FlashFwdRunner::Run<false, 64, device_gemm_trait::BFloat16, true, true>() {
 
 // hdim 64, bf16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<false, 64, device_gemm_trait::BFloat16, true, false>() {
+void FlashFwdRunner::Run<false, 64, device_gemm_trait::BFloat16, true, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim64,
                   device_gemm_trait::BFloat16, 

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_bf16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_bf16_causal_gfx90a.cpp
@@ -24,12 +24,25 @@
 #include "flash_fwd_runner_gfx90a.h"
 
 namespace fwd_device_gemm {
-// hdim 64, bf16, non-causal
+// hdim 64, bf16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<false, 64, device_gemm_trait::BFloat16, true>() {
+void FlashFwdRunner::Run<false, 64, device_gemm_trait::BFloat16, true, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim64,
                   device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kMaskingSpecCausal,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
+// hdim 64, bf16, non-causal, MNKO-padding
+template <>
+void FlashFwdRunner::Run<false, 64, device_gemm_trait::BFloat16, true, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmKLoopHeadDim64,
+                  device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecPadding,
                   device_gemm_trait::kMaskingSpecCausal,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_bf16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_bf16_causal_gfx90a.cpp
@@ -36,13 +36,13 @@ void FlashFwdRunner::Run<false, 64, device_gemm_trait::BFloat16, true, true>(boo
   });
 } // FlashFwdRunner::Run()
 
-// hdim 64, bf16, non-causal, MNKO-padding
+// hdim 64, bf16, non-causal, non-padding
 template <>
 void FlashFwdRunner::Run<false, 64, device_gemm_trait::BFloat16, true, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim64,
                   device_gemm_trait::BFloat16, 
-                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kGemmSpecDefault,
                   device_gemm_trait::kMaskingSpecCausal,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_bf16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_bf16_noncausal_gfx90a.cpp
@@ -24,7 +24,7 @@
 #include "flash_fwd_runner_gfx90a.h"
 
 namespace fwd_device_gemm {
-// hdim 64, bf16, non-causal
+// hdim 64, bf16, non-causal, MNKO-padding
 template <>
 void FlashFwdRunner::Run<false, 64, device_gemm_trait::BFloat16, false, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
@@ -36,13 +36,13 @@ void FlashFwdRunner::Run<false, 64, device_gemm_trait::BFloat16, false, true>(bo
   });
 } // FlashFwdRunner::Run()
 
-// hdim 64, bf16, non-causal
+// hdim 64, bf16, non-causal, non-padding
 template <>
 void FlashFwdRunner::Run<false, 64, device_gemm_trait::BFloat16, false, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim64,
                   device_gemm_trait::BFloat16, 
-                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kGemmSpecDefault,
                   device_gemm_trait::kMaskingSpecDefault,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_bf16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_bf16_noncausal_gfx90a.cpp
@@ -26,10 +26,23 @@
 namespace fwd_device_gemm {
 // hdim 64, bf16, non-causal
 template <>
-void FlashFwdRunner::Run<false, 64, device_gemm_trait::BFloat16, false>() {
+void FlashFwdRunner::Run<false, 64, device_gemm_trait::BFloat16, false, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim64,
                   device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kMaskingSpecDefault,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
+// hdim 64, bf16, non-causal
+template <>
+void FlashFwdRunner::Run<false, 64, device_gemm_trait::BFloat16, false, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmKLoopHeadDim64,
+                  device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecPadding,
                   device_gemm_trait::kMaskingSpecDefault,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_bf16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_bf16_noncausal_gfx90a.cpp
@@ -26,7 +26,7 @@
 namespace fwd_device_gemm {
 // hdim 64, bf16, non-causal
 template <>
-void FlashFwdRunner::Run<false, 64, device_gemm_trait::BFloat16, false, true>() {
+void FlashFwdRunner::Run<false, 64, device_gemm_trait::BFloat16, false, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim64,
                   device_gemm_trait::BFloat16, 
@@ -38,7 +38,7 @@ void FlashFwdRunner::Run<false, 64, device_gemm_trait::BFloat16, false, true>() 
 
 // hdim 64, bf16, non-causal
 template <>
-void FlashFwdRunner::Run<false, 64, device_gemm_trait::BFloat16, false, false>() {
+void FlashFwdRunner::Run<false, 64, device_gemm_trait::BFloat16, false, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim64,
                   device_gemm_trait::BFloat16, 

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_fp16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_fp16_causal_gfx90a.cpp
@@ -36,13 +36,13 @@ void FlashFwdRunner::Run<false, 64, device_gemm_trait::Float16, true, true>(bool
   });
 } // FlashFwdRunner::Run()
 
-// hdim 64, fp16, causal
+// hdim 64, fp16, causal, non-padding
 template <>
 void FlashFwdRunner::Run<false, 64, device_gemm_trait::Float16, true, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim64,
                   device_gemm_trait::Float16, 
-                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kGemmSpecDefault,
                   device_gemm_trait::kMaskingSpecCausal,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_fp16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_fp16_causal_gfx90a.cpp
@@ -26,10 +26,23 @@
 namespace fwd_device_gemm {
 // hdim 64, fp16, causal
 template <>
-void FlashFwdRunner::Run<false, 64, device_gemm_trait::Float16, true>() {
+void FlashFwdRunner::Run<false, 64, device_gemm_trait::Float16, true, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim64,
                   device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kMaskingSpecCausal,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
+// hdim 64, fp16, causal
+template <>
+void FlashFwdRunner::Run<false, 64, device_gemm_trait::Float16, true, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmKLoopHeadDim64,
+                  device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecPadding,
                   device_gemm_trait::kMaskingSpecCausal,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_fp16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_fp16_causal_gfx90a.cpp
@@ -26,7 +26,7 @@
 namespace fwd_device_gemm {
 // hdim 64, fp16, causal
 template <>
-void FlashFwdRunner::Run<false, 64, device_gemm_trait::Float16, true, true>() {
+void FlashFwdRunner::Run<false, 64, device_gemm_trait::Float16, true, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim64,
                   device_gemm_trait::Float16, 
@@ -38,7 +38,7 @@ void FlashFwdRunner::Run<false, 64, device_gemm_trait::Float16, true, true>() {
 
 // hdim 64, fp16, causal
 template <>
-void FlashFwdRunner::Run<false, 64, device_gemm_trait::Float16, true, false>() {
+void FlashFwdRunner::Run<false, 64, device_gemm_trait::Float16, true, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim64,
                   device_gemm_trait::Float16, 

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_fp16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_fp16_noncausal_gfx90a.cpp
@@ -26,10 +26,23 @@
 namespace fwd_device_gemm {
 // hdim 64, fp16, non-causal
 template <>
-void FlashFwdRunner::Run<false, 64, device_gemm_trait::Float16, false>() {
+void FlashFwdRunner::Run<false, 64, device_gemm_trait::Float16, false, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim64,
                   device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kMaskingSpecDefault,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
+// hdim 64, fp16, non-causal
+template <>
+void FlashFwdRunner::Run<false, 64, device_gemm_trait::Float16, false, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmKLoopHeadDim64,
+                  device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecPadding,
                   device_gemm_trait::kMaskingSpecDefault,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_fp16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_fp16_noncausal_gfx90a.cpp
@@ -26,7 +26,7 @@
 namespace fwd_device_gemm {
 // hdim 64, fp16, non-causal
 template <>
-void FlashFwdRunner::Run<false, 64, device_gemm_trait::Float16, false, true>() {
+void FlashFwdRunner::Run<false, 64, device_gemm_trait::Float16, false, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim64,
                   device_gemm_trait::Float16, 
@@ -38,7 +38,7 @@ void FlashFwdRunner::Run<false, 64, device_gemm_trait::Float16, false, true>() {
 
 // hdim 64, fp16, non-causal
 template <>
-void FlashFwdRunner::Run<false, 64, device_gemm_trait::Float16, false, false>() {
+void FlashFwdRunner::Run<false, 64, device_gemm_trait::Float16, false, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim64,
                   device_gemm_trait::Float16, 

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_fp16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_kloop_hdim64_fp16_noncausal_gfx90a.cpp
@@ -24,7 +24,7 @@
 #include "flash_fwd_runner_gfx90a.h"
 
 namespace fwd_device_gemm {
-// hdim 64, fp16, non-causal
+// hdim 64, fp16, non-causal, MNKO-padding
 template <>
 void FlashFwdRunner::Run<false, 64, device_gemm_trait::Float16, false, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
@@ -36,13 +36,13 @@ void FlashFwdRunner::Run<false, 64, device_gemm_trait::Float16, false, true>(boo
   });
 } // FlashFwdRunner::Run()
 
-// hdim 64, fp16, non-causal
+// hdim 64, fp16, non-causal, non-padding
 template <>
 void FlashFwdRunner::Run<false, 64, device_gemm_trait::Float16, false, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmKLoopHeadDim64,
                   device_gemm_trait::Float16, 
-                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kGemmSpecDefault,
                   device_gemm_trait::kMaskingSpecDefault,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim128_bf16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim128_bf16_causal_gfx90a.cpp
@@ -24,12 +24,25 @@
 #include "flash_fwd_runner_gfx90a.h"
 
 namespace fwd_device_gemm {
-// hdim 128, bf16, non-causal
+// hdim 128, bf16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<true, 128, device_gemm_trait::BFloat16, true>() {
+void FlashFwdRunner::Run<true, 128, device_gemm_trait::BFloat16, true, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim128,
                   device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kMaskingSpecCausal,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
+// hdim 128, bf16, non-causal, non-padding
+template <>
+void FlashFwdRunner::Run<true, 128, device_gemm_trait::BFloat16, true, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmQLoopHeadDim128,
+                  device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecDefault,
                   device_gemm_trait::kMaskingSpecCausal,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim128_bf16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim128_bf16_causal_gfx90a.cpp
@@ -26,7 +26,7 @@
 namespace fwd_device_gemm {
 // hdim 128, bf16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<true, 128, device_gemm_trait::BFloat16, true, true>() {
+void FlashFwdRunner::Run<true, 128, device_gemm_trait::BFloat16, true, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim128,
                   device_gemm_trait::BFloat16, 
@@ -38,7 +38,7 @@ void FlashFwdRunner::Run<true, 128, device_gemm_trait::BFloat16, true, true>() {
 
 // hdim 128, bf16, non-causal, non-padding
 template <>
-void FlashFwdRunner::Run<true, 128, device_gemm_trait::BFloat16, true, false>() {
+void FlashFwdRunner::Run<true, 128, device_gemm_trait::BFloat16, true, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim128,
                   device_gemm_trait::BFloat16, 

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim128_bf16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim128_bf16_noncausal_gfx90a.cpp
@@ -26,7 +26,7 @@
 namespace fwd_device_gemm {
 // hdim 128, bf16, non-causal
 template <>
-void FlashFwdRunner::Run<true, 128, device_gemm_trait::BFloat16, false, true>() {
+void FlashFwdRunner::Run<true, 128, device_gemm_trait::BFloat16, false, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim128,
                   device_gemm_trait::BFloat16, 
@@ -38,7 +38,7 @@ void FlashFwdRunner::Run<true, 128, device_gemm_trait::BFloat16, false, true>() 
 
 // hdim 128, bf16, non-causal
 template <>
-void FlashFwdRunner::Run<true, 128, device_gemm_trait::BFloat16, false, false>() {
+void FlashFwdRunner::Run<true, 128, device_gemm_trait::BFloat16, false, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim128,
                   device_gemm_trait::BFloat16, 

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim128_bf16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim128_bf16_noncausal_gfx90a.cpp
@@ -26,10 +26,23 @@
 namespace fwd_device_gemm {
 // hdim 128, bf16, non-causal
 template <>
-void FlashFwdRunner::Run<true, 128, device_gemm_trait::BFloat16, false>() {
+void FlashFwdRunner::Run<true, 128, device_gemm_trait::BFloat16, false, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim128,
                   device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kMaskingSpecDefault,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
+// hdim 128, bf16, non-causal
+template <>
+void FlashFwdRunner::Run<true, 128, device_gemm_trait::BFloat16, false, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmQLoopHeadDim128,
+                  device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecDefault,
                   device_gemm_trait::kMaskingSpecDefault,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim128_fp16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim128_fp16_causal_gfx90a.cpp
@@ -26,7 +26,7 @@
 namespace fwd_device_gemm {
 // hdim 128, fp16, causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<true, 128, device_gemm_trait::Float16, true, true>() {
+void FlashFwdRunner::Run<true, 128, device_gemm_trait::Float16, true, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim128,
                   device_gemm_trait::Float16, 
@@ -38,7 +38,7 @@ void FlashFwdRunner::Run<true, 128, device_gemm_trait::Float16, true, true>() {
 
 // hdim 128, fp16, causal, non-padding
 template <>
-void FlashFwdRunner::Run<true, 128, device_gemm_trait::Float16, true, false>() {
+void FlashFwdRunner::Run<true, 128, device_gemm_trait::Float16, true, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim128,
                   device_gemm_trait::Float16, 

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim128_fp16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim128_fp16_causal_gfx90a.cpp
@@ -24,12 +24,25 @@
 #include "flash_fwd_runner_gfx90a.h"
 
 namespace fwd_device_gemm {
-// hdim 128, fp16, causal
+// hdim 128, fp16, causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<true, 128, device_gemm_trait::Float16, true>() {
+void FlashFwdRunner::Run<true, 128, device_gemm_trait::Float16, true, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim128,
                   device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kMaskingSpecCausal,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
+// hdim 128, fp16, causal, non-padding
+template <>
+void FlashFwdRunner::Run<true, 128, device_gemm_trait::Float16, true, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmQLoopHeadDim128,
+                  device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecDefault,
                   device_gemm_trait::kMaskingSpecCausal,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim128_fp16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim128_fp16_noncausal_gfx90a.cpp
@@ -26,7 +26,7 @@
 namespace fwd_device_gemm {
 // hdim 128, fp16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<true, 128, device_gemm_trait::Float16, false, true>() {
+void FlashFwdRunner::Run<true, 128, device_gemm_trait::Float16, false, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim128,
                   device_gemm_trait::Float16, 
@@ -38,7 +38,7 @@ void FlashFwdRunner::Run<true, 128, device_gemm_trait::Float16, false, true>() {
 
 // hdim 128, fp16, non-causal, non-padding
 template <>
-void FlashFwdRunner::Run<true, 128, device_gemm_trait::Float16, false, false>() {
+void FlashFwdRunner::Run<true, 128, device_gemm_trait::Float16, false, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim128,
                   device_gemm_trait::Float16, 

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim128_fp16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim128_fp16_noncausal_gfx90a.cpp
@@ -24,12 +24,25 @@
 #include "flash_fwd_runner_gfx90a.h"
 
 namespace fwd_device_gemm {
-// hdim 128, fp16, non-causal
+// hdim 128, fp16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<true, 128, device_gemm_trait::Float16, false>() {
+void FlashFwdRunner::Run<true, 128, device_gemm_trait::Float16, false, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim128,
                   device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kMaskingSpecDefault,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
+// hdim 128, fp16, non-causal, non-padding
+template <>
+void FlashFwdRunner::Run<true, 128, device_gemm_trait::Float16, false, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmQLoopHeadDim128,
+                  device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecDefault,
                   device_gemm_trait::kMaskingSpecDefault,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim32_bf16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim32_bf16_causal_gfx90a.cpp
@@ -26,7 +26,7 @@
 namespace fwd_device_gemm {
 // hdim 32, bf16, causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<true, 32, device_gemm_trait::BFloat16, true, true>() {
+void FlashFwdRunner::Run<true, 32, device_gemm_trait::BFloat16, true, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim32,
                   device_gemm_trait::BFloat16, 
@@ -38,7 +38,7 @@ void FlashFwdRunner::Run<true, 32, device_gemm_trait::BFloat16, true, true>() {
 
 // hdim 32, bf16, causal, non-padding
 template <>
-void FlashFwdRunner::Run<true, 32, device_gemm_trait::BFloat16, true, false>() {
+void FlashFwdRunner::Run<true, 32, device_gemm_trait::BFloat16, true, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim32,
                   device_gemm_trait::BFloat16, 

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim32_bf16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim32_bf16_causal_gfx90a.cpp
@@ -24,14 +24,28 @@
 #include "flash_fwd_runner_gfx90a.h"
 
 namespace fwd_device_gemm {
-// hdim 32, bf16, causal
+// hdim 32, bf16, causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<true, 32, device_gemm_trait::BFloat16, true>() {
+void FlashFwdRunner::Run<true, 32, device_gemm_trait::BFloat16, true, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim32,
                   device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecPadding,
                   device_gemm_trait::kMaskingSpecCausal,
                   kIsDeterministic>();
   });
 } // FlashFwdRunner::Run()
+
+// hdim 32, bf16, causal, non-padding
+template <>
+void FlashFwdRunner::Run<true, 32, device_gemm_trait::BFloat16, true, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmQLoopHeadDim32,
+                  device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecDefault,
+                  device_gemm_trait::kMaskingSpecCausal,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
 } // namespace fwd_device_gemm

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim32_bf16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim32_bf16_noncausal_gfx90a.cpp
@@ -26,7 +26,7 @@
 namespace fwd_device_gemm {
 // hdim 32, bf16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<true, 32, device_gemm_trait::BFloat16, false, true>() {
+void FlashFwdRunner::Run<true, 32, device_gemm_trait::BFloat16, false, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim32,
                   device_gemm_trait::BFloat16, 
@@ -38,7 +38,7 @@ void FlashFwdRunner::Run<true, 32, device_gemm_trait::BFloat16, false, true>() {
 
 // hdim 32, bf16, non-causal, non-padding
 template <>
-void FlashFwdRunner::Run<true, 32, device_gemm_trait::BFloat16, false, false>() {
+void FlashFwdRunner::Run<true, 32, device_gemm_trait::BFloat16, false, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim32,
                   device_gemm_trait::BFloat16, 

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim32_bf16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim32_bf16_noncausal_gfx90a.cpp
@@ -24,12 +24,25 @@
 #include "flash_fwd_runner_gfx90a.h"
 
 namespace fwd_device_gemm {
-// hdim 32, bf16, non-causal
+// hdim 32, bf16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<true, 32, device_gemm_trait::BFloat16, false>() {
+void FlashFwdRunner::Run<true, 32, device_gemm_trait::BFloat16, false, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim32,
                   device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kMaskingSpecDefault,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
+// hdim 32, bf16, non-causal, non-padding
+template <>
+void FlashFwdRunner::Run<true, 32, device_gemm_trait::BFloat16, false, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmQLoopHeadDim32,
+                  device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecDefault,
                   device_gemm_trait::kMaskingSpecDefault,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim32_fp16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim32_fp16_causal_gfx90a.cpp
@@ -26,7 +26,7 @@
 namespace fwd_device_gemm {
 // hdim 32, bf16, causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<true, 32, device_gemm_trait::Float16, true, true>() {
+void FlashFwdRunner::Run<true, 32, device_gemm_trait::Float16, true, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim32,
                   device_gemm_trait::Float16, 
@@ -38,7 +38,7 @@ void FlashFwdRunner::Run<true, 32, device_gemm_trait::Float16, true, true>() {
 
 // hdim 32, bf16, causal, non-padding
 template <>
-void FlashFwdRunner::Run<true, 32, device_gemm_trait::Float16, true, false>() {
+void FlashFwdRunner::Run<true, 32, device_gemm_trait::Float16, true, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim32,
                   device_gemm_trait::Float16, 

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim32_fp16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim32_fp16_causal_gfx90a.cpp
@@ -24,12 +24,25 @@
 #include "flash_fwd_runner_gfx90a.h"
 
 namespace fwd_device_gemm {
-// hdim 32, fp16, causal
+// hdim 32, bf16, causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<true, 32, device_gemm_trait::Float16, true>() {
+void FlashFwdRunner::Run<true, 32, device_gemm_trait::Float16, true, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim32,
                   device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kMaskingSpecCausal,
+                  kIsDeterministic>();
+  });
+}
+
+// hdim 32, bf16, causal, non-padding
+template <>
+void FlashFwdRunner::Run<true, 32, device_gemm_trait::Float16, true, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmQLoopHeadDim32,
+                  device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecDefault,
                   device_gemm_trait::kMaskingSpecCausal,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim32_fp16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim32_fp16_noncausal_gfx90a.cpp
@@ -24,12 +24,25 @@
 #include "flash_fwd_runner_gfx90a.h"
 
 namespace fwd_device_gemm {
-// hdim 32, fp16, non-causal
+// hdim 32, bf16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<true, 32, device_gemm_trait::Float16, false>() {
+void FlashFwdRunner::Run<true, 32, device_gemm_trait::Float16, false, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim32,
                   device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kMaskingSpecDefault,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
+// hdim 32, bf16, non-causal, non-padding
+template <>
+void FlashFwdRunner::Run<true, 32, device_gemm_trait::Float16, false, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmQLoopHeadDim32,
+                  device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecDefault,
                   device_gemm_trait::kMaskingSpecDefault,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim32_fp16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim32_fp16_noncausal_gfx90a.cpp
@@ -26,7 +26,7 @@
 namespace fwd_device_gemm {
 // hdim 32, bf16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<true, 32, device_gemm_trait::Float16, false, true>() {
+void FlashFwdRunner::Run<true, 32, device_gemm_trait::Float16, false, true>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim32,
                   device_gemm_trait::Float16, 
@@ -38,7 +38,7 @@ void FlashFwdRunner::Run<true, 32, device_gemm_trait::Float16, false, true>() {
 
 // hdim 32, bf16, non-causal, non-padding
 template <>
-void FlashFwdRunner::Run<true, 32, device_gemm_trait::Float16, false, false>() {
+void FlashFwdRunner::Run<true, 32, device_gemm_trait::Float16, false, false>(bool is_dropout) {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim32,
                   device_gemm_trait::Float16, 

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim64_bf16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim64_bf16_causal_gfx90a.cpp
@@ -26,25 +26,47 @@
 namespace fwd_device_gemm {
 // hdim 64, bf16, causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<true, 64, device_gemm_trait::BFloat16, true, true>() {
-  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
-    this->template run_<DeviceGemmQLoopHeadDim64,
-                  device_gemm_trait::BFloat16, 
-                  device_gemm_trait::kGemmSpecPadding,
-                  device_gemm_trait::kMaskingSpecCausal,
-                  kIsDeterministic>();
+void FlashFwdRunner::Run<true, 64, device_gemm_trait::BFloat16, true, true>(bool is_dropout) {
+  if(is_dropout){
+    BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+      this->template run_<DeviceGemmQLoopHeadDim64,
+                    device_gemm_trait::BFloat16, 
+                    device_gemm_trait::kGemmSpecPadding,
+                    device_gemm_trait::kMaskingSpecCausal,
+                    kIsDeterministic>();
   });
+  }
+  else{
+    BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+      this->template run_<DeviceGemmQLoopHeadDim64NonDrop,
+                    device_gemm_trait::BFloat16, 
+                    device_gemm_trait::kGemmSpecPadding,
+                    device_gemm_trait::kMaskingSpecCausal,
+                    kIsDeterministic>();
+    });
+  }
 } // FlashFwdRunner::Run()
 
 // hdim 64, bf16, causal, non-padding
 template <>
-void FlashFwdRunner::Run<true, 64, device_gemm_trait::BFloat16, true, false>() {
-  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
-    this->template run_<DeviceGemmQLoopHeadDim64,
-                  device_gemm_trait::BFloat16, 
-                  device_gemm_trait::kGemmSpecDefault,
-                  device_gemm_trait::kMaskingSpecCausal,
-                  kIsDeterministic>();
-  });
+void FlashFwdRunner::Run<true, 64, device_gemm_trait::BFloat16, true, false>(bool is_dropout) {
+  if(is_dropout){
+    BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+      this->template run_<DeviceGemmQLoopHeadDim64,
+                    device_gemm_trait::BFloat16, 
+                    device_gemm_trait::kGemmSpecDefault,
+                    device_gemm_trait::kMaskingSpecCausal,
+                    kIsDeterministic>();
+    });
+  }
+  else{
+    BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+      this->template run_<DeviceGemmQLoopHeadDim64NonDrop,
+                    device_gemm_trait::BFloat16, 
+                    device_gemm_trait::kGemmSpecDefault,
+                    device_gemm_trait::kMaskingSpecCausal,
+                    kIsDeterministic>();
+    });
+  }
 } // FlashFwdRunner::Run()
 } // namespace fwd_device_gemm

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim64_bf16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim64_bf16_causal_gfx90a.cpp
@@ -24,12 +24,25 @@
 #include "flash_fwd_runner_gfx90a.h"
 
 namespace fwd_device_gemm {
-// hdim 64, bf16, causal
+// hdim 64, bf16, causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<true, 64, device_gemm_trait::BFloat16, true>() {
+void FlashFwdRunner::Run<true, 64, device_gemm_trait::BFloat16, true, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim64,
                   device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kMaskingSpecCausal,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
+// hdim 64, bf16, causal, non-padding
+template <>
+void FlashFwdRunner::Run<true, 64, device_gemm_trait::BFloat16, true, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmQLoopHeadDim64,
+                  device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecDefault,
                   device_gemm_trait::kMaskingSpecCausal,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim64_bf16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim64_bf16_noncausal_gfx90a.cpp
@@ -26,25 +26,47 @@
 namespace fwd_device_gemm {
 // hdim 64, bf16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<true, 64, device_gemm_trait::BFloat16, false, true>() {
-  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
-    this->template run_<DeviceGemmQLoopHeadDim64,
-                  device_gemm_trait::BFloat16, 
-                  device_gemm_trait::kGemmSpecPadding,
-                  device_gemm_trait::kMaskingSpecDefault,
-                  kIsDeterministic>();
-  });
+void FlashFwdRunner::Run<true, 64, device_gemm_trait::BFloat16, false, true>(bool is_dropout) {
+  if(is_dropout){
+    BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+      this->template run_<DeviceGemmQLoopHeadDim64,
+                    device_gemm_trait::BFloat16, 
+                    device_gemm_trait::kGemmSpecPadding,
+                    device_gemm_trait::kMaskingSpecDefault,
+                    kIsDeterministic>();
+    });
+  }
+  else{
+    BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+      this->template run_<DeviceGemmQLoopHeadDim64NonDrop,
+                    device_gemm_trait::BFloat16, 
+                    device_gemm_trait::kGemmSpecPadding,
+                    device_gemm_trait::kMaskingSpecDefault,
+                    kIsDeterministic>();
+    });
+  }
 } // FlashFwdRunner::Run()
 
 // hdim 64, bf16, non-causal, non-padding
 template <>
-void FlashFwdRunner::Run<true, 64, device_gemm_trait::BFloat16, false, false>() {
-  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
-    this->template run_<DeviceGemmQLoopHeadDim64,
-                  device_gemm_trait::BFloat16, 
-                  device_gemm_trait::kGemmSpecDefault,
-                  device_gemm_trait::kMaskingSpecDefault,
-                  kIsDeterministic>();
-  });
+void FlashFwdRunner::Run<true, 64, device_gemm_trait::BFloat16, false, false>(bool is_dropout) {
+  if(is_dropout){
+    BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+      this->template run_<DeviceGemmQLoopHeadDim64,
+                    device_gemm_trait::BFloat16, 
+                    device_gemm_trait::kGemmSpecDefault,
+                    device_gemm_trait::kMaskingSpecDefault,
+                    kIsDeterministic>();
+    });
+  }
+  else{
+    BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+      this->template run_<DeviceGemmQLoopHeadDim64NonDrop,
+                    device_gemm_trait::BFloat16, 
+                    device_gemm_trait::kGemmSpecDefault,
+                    device_gemm_trait::kMaskingSpecDefault,
+                    kIsDeterministic>();
+    });
+  }
 } // FlashFwdRunner::Run()
 } // namespace fwd_device_gemm

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim64_bf16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim64_bf16_noncausal_gfx90a.cpp
@@ -24,12 +24,25 @@
 #include "flash_fwd_runner_gfx90a.h"
 
 namespace fwd_device_gemm {
-// hdim 64, bf16, non-causal
+// hdim 64, bf16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<true, 64, device_gemm_trait::BFloat16, false>() {
+void FlashFwdRunner::Run<true, 64, device_gemm_trait::BFloat16, false, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim64,
                   device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kMaskingSpecDefault,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
+// hdim 64, bf16, non-causal, non-padding
+template <>
+void FlashFwdRunner::Run<true, 64, device_gemm_trait::BFloat16, false, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmQLoopHeadDim64,
+                  device_gemm_trait::BFloat16, 
+                  device_gemm_trait::kGemmSpecDefault,
                   device_gemm_trait::kMaskingSpecDefault,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim64_fp16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim64_fp16_causal_gfx90a.cpp
@@ -26,25 +26,47 @@
 namespace fwd_device_gemm {
 // hdim 64, fp16, causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<true, 64, device_gemm_trait::Float16, true, true>() {
-  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
-    this->template run_<DeviceGemmQLoopHeadDim64,
-                  device_gemm_trait::Float16, 
-                  device_gemm_trait::kGemmSpecPadding,
-                  device_gemm_trait::kMaskingSpecCausal,
-                  kIsDeterministic>();
-  });
+void FlashFwdRunner::Run<true, 64, device_gemm_trait::Float16, true, true>(bool is_dropout) {
+  if(is_dropout){
+    BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+      this->template run_<DeviceGemmQLoopHeadDim64,
+                    device_gemm_trait::Float16, 
+                    device_gemm_trait::kGemmSpecPadding,
+                    device_gemm_trait::kMaskingSpecCausal,
+                    kIsDeterministic>();
+    });
+  }
+  else{
+    BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+      this->template run_<DeviceGemmQLoopHeadDim64NonDrop,
+                    device_gemm_trait::Float16, 
+                    device_gemm_trait::kGemmSpecPadding,
+                    device_gemm_trait::kMaskingSpecCausal,
+                    kIsDeterministic>();
+    });
+  }
 } // FlashFwdRunner::Run()
 
 // hdim 64, fp16, causal, non-padding
 template <>
-void FlashFwdRunner::Run<true, 64, device_gemm_trait::Float16, true, false>() {
-  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
-    this->template run_<DeviceGemmQLoopHeadDim64,
-                  device_gemm_trait::Float16, 
-                  device_gemm_trait::kGemmSpecDefault,
-                  device_gemm_trait::kMaskingSpecCausal,
-                  kIsDeterministic>();
-  });
+void FlashFwdRunner::Run<true, 64, device_gemm_trait::Float16, true, false>(bool is_dropout) {
+  if(is_dropout){
+    BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+      this->template run_<DeviceGemmQLoopHeadDim64,
+                    device_gemm_trait::Float16, 
+                    device_gemm_trait::kGemmSpecDefault,
+                    device_gemm_trait::kMaskingSpecCausal,
+                    kIsDeterministic>();
+    });
+  }
+  else{
+    BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+      this->template run_<DeviceGemmQLoopHeadDim64NonDrop,
+                    device_gemm_trait::Float16, 
+                    device_gemm_trait::kGemmSpecDefault,
+                    device_gemm_trait::kMaskingSpecCausal,
+                    kIsDeterministic>();
+    });
+  }
 } // FlashFwdRunner::Run()
 } // namespace fwd_device_gemm

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim64_fp16_causal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim64_fp16_causal_gfx90a.cpp
@@ -24,12 +24,25 @@
 #include "flash_fwd_runner_gfx90a.h"
 
 namespace fwd_device_gemm {
-// hdim 64, fp16, causal
+// hdim 64, fp16, causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<true, 64, device_gemm_trait::Float16, true>() {
+void FlashFwdRunner::Run<true, 64, device_gemm_trait::Float16, true, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim64,
                   device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecPadding,
+                  device_gemm_trait::kMaskingSpecCausal,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
+// hdim 64, fp16, causal, non-padding
+template <>
+void FlashFwdRunner::Run<true, 64, device_gemm_trait::Float16, true, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmQLoopHeadDim64,
+                  device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecDefault,
                   device_gemm_trait::kMaskingSpecCausal,
                   kIsDeterministic>();
   });

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim64_fp16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim64_fp16_noncausal_gfx90a.cpp
@@ -26,25 +26,47 @@
 namespace fwd_device_gemm {
 // hdim 64, fp16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<true, 64, device_gemm_trait::Float16, false, true>() {
-  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
-    this->template run_<DeviceGemmQLoopHeadDim64,
-                  device_gemm_trait::Float16, 
-                  device_gemm_trait::kGemmSpecPadding,
-                  device_gemm_trait::kMaskingSpecDefault,
-                  kIsDeterministic>();
-  });
+void FlashFwdRunner::Run<true, 64, device_gemm_trait::Float16, false, true>(bool is_dropout) {
+  if(is_dropout){
+    BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+      this->template run_<DeviceGemmQLoopHeadDim64,
+                    device_gemm_trait::Float16, 
+                    device_gemm_trait::kGemmSpecPadding,
+                    device_gemm_trait::kMaskingSpecDefault,
+                    kIsDeterministic>();
+    });    
+  }
+  else{
+    BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+      this->template run_<DeviceGemmQLoopHeadDim64NonDrop,
+                    device_gemm_trait::Float16, 
+                    device_gemm_trait::kGemmSpecPadding,
+                    device_gemm_trait::kMaskingSpecDefault,
+                    kIsDeterministic>();
+    });
+  }
 } // FlashFwdRunner::Run()
 
 // hdim 64, fp16, causal, non-padding
 template <>
-void FlashFwdRunner::Run<true, 64, device_gemm_trait::Float16, false, false>() {
-  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
-    this->template run_<DeviceGemmQLoopHeadDim64,
-                  device_gemm_trait::Float16, 
-                  device_gemm_trait::kGemmSpecDefault,
-                  device_gemm_trait::kMaskingSpecDefault,
-                  kIsDeterministic>();
-  });
+void FlashFwdRunner::Run<true, 64, device_gemm_trait::Float16, false, false>(bool is_dropout) {
+  if(is_dropout){
+    BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+      this->template run_<DeviceGemmQLoopHeadDim64,
+                    device_gemm_trait::Float16, 
+                    device_gemm_trait::kGemmSpecDefault,
+                    device_gemm_trait::kMaskingSpecDefault,
+                    kIsDeterministic>();
+    });
+  }
+  else{
+    BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+      this->template run_<DeviceGemmQLoopHeadDim64NonDrop,
+                    device_gemm_trait::Float16, 
+                    device_gemm_trait::kGemmSpecDefault,
+                    device_gemm_trait::kMaskingSpecDefault,
+                    kIsDeterministic>();
+    });    
+  }
 } // FlashFwdRunner::Run()
 } // namespace fwd_device_gemm

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim64_fp16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim64_fp16_noncausal_gfx90a.cpp
@@ -24,13 +24,26 @@
 #include "flash_fwd_runner_gfx90a.h"
 
 namespace fwd_device_gemm {
-// hdim 64, fp16, non-causal
+// hdim 64, fp16, non-causal, MNKO-padding
 template <>
-void FlashFwdRunner::Run<true, 64, device_gemm_trait::Float16, false>() {
+void FlashFwdRunner::Run<true, 64, device_gemm_trait::Float16, false, true>() {
   BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
     this->template run_<DeviceGemmQLoopHeadDim64,
                   device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecPadding,
                   device_gemm_trait::kMaskingSpecDefault,
+                  kIsDeterministic>();
+  });
+} // FlashFwdRunner::Run()
+
+// hdim 64, fp16, causal, non-padding
+template <>
+void FlashFwdRunner::Run<true, 64, device_gemm_trait::Float16, false, false>() {
+  BOOL_SWITCH(is_deterministic_, kIsDeterministic, [&] {
+    this->template run_<DeviceGemmQLoopHeadDim64,
+                  device_gemm_trait::Float16, 
+                  device_gemm_trait::kGemmSpecDefault,
+                  device_gemm_trait::kMaskingSpecCausal,
                   kIsDeterministic>();
   });
 } // FlashFwdRunner::Run()

--- a/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim64_fp16_noncausal_gfx90a.cpp
+++ b/csrc/flash_attn_rocm/src/flash_fwd_runner_qloop_hdim64_fp16_noncausal_gfx90a.cpp
@@ -43,7 +43,7 @@ void FlashFwdRunner::Run<true, 64, device_gemm_trait::Float16, false, false>() {
     this->template run_<DeviceGemmQLoopHeadDim64,
                   device_gemm_trait::Float16, 
                   device_gemm_trait::kGemmSpecDefault,
-                  device_gemm_trait::kMaskingSpecCausal,
+                  device_gemm_trait::kMaskingSpecDefault,
                   kIsDeterministic>();
   });
 } // FlashFwdRunner::Run()

--- a/csrc/flash_attn_rocm/src/fwd_device_gemm_template.h
+++ b/csrc/flash_attn_rocm/src/fwd_device_gemm_template.h
@@ -169,6 +169,78 @@ using DeviceGemmQLoopHeadDim64 = device_op::DeviceGroupedMultiheadAttentionForwa
         8,                                    // CShuffleBlockTransferScalarPerVector_NPerBlock
         DeviceGemmTraits::kMaskingSpec,                      // MaskingSpecialization
         DeviceGemmTraits::kIsDeterministic>;
+// type alias for DeviceGroupedMultiheadAttentionForward_Xdl_CShuffle with head_dim = 64
+template <typename DeviceGemmTraits>
+using DeviceGemmQLoopHeadDim64NonDrop = device_op::DeviceGroupedMultiheadAttentionForward_Xdl_CShuffle_V2<
+        DeviceGemmTraits::kNumDimG, 
+        DeviceGemmTraits::kNumDimM, 
+        DeviceGemmTraits::kNumDimN, 
+        DeviceGemmTraits::kNumDimK, 
+        DeviceGemmTraits::kNumDimO, 
+        typename DeviceGemmTraits::ADataType,
+        typename DeviceGemmTraits::B0DataType,
+        typename DeviceGemmTraits::B1DataType,
+        typename DeviceGemmTraits::CDataType,
+        typename DeviceGemmTraits::GemmDataType,
+        typename DeviceGemmTraits::ZDataType,
+        typename DeviceGemmTraits::LSEDataType,
+        typename DeviceGemmTraits::Acc0BiasDataType,
+        typename DeviceGemmTraits::Acc1BiasDataType,
+        typename DeviceGemmTraits::AccDataType,
+        typename DeviceGemmTraits::CShuffleDataType,
+        typename DeviceGemmTraits::AElementOp,
+        typename DeviceGemmTraits::B0ElementOp,
+        typename DeviceGemmTraits::Acc0ElementOp,
+        typename DeviceGemmTraits::B1ElementOp,
+        typename DeviceGemmTraits::CElementOp,
+        DeviceGemmTraits::kGemmSpec,
+        DeviceGemmTraits::kTensorSpecA,
+        DeviceGemmTraits::kTensorSpecB0,
+        DeviceGemmTraits::kTensorSpecB1,
+        DeviceGemmTraits::kTensorSpecC,
+        1,
+        256,
+        128,         // MPerBlock
+        256,         // NPerBlock
+        32,         // KPerBlock
+        64,    // Gemm1NPerBlock
+        32,    // Gemm1KPerBlock
+        8,                 // AK1
+        8,                 // BK1
+        2,                 // B1K1
+        32,           // MPerXDL
+        32,           // NPerXDL
+        1,                 // MXdlPerWave
+        8,       // NXdlPerWave
+        2,  // Gemm1NXdlPerWave
+        device_gemm_trait::S<4, 64, 1>,    // ABlockTransfer
+        device_gemm_trait::S<1, 0, 2>,
+        device_gemm_trait::S<1, 0, 2>,
+        2,
+        8,
+        8,
+        true,   // ABlockLdsExtraM
+        device_gemm_trait::S<4, 64, 1>,    // BBlockTransfer
+        device_gemm_trait::S<1, 0, 2>,
+        device_gemm_trait::S<1, 0, 2>,
+        2,
+        8,
+        8,
+        true,  // B0BlockLdsExtraN
+        device_gemm_trait::S<16, 16, 1>,   // B1BlockTransfer
+        device_gemm_trait::S<0, 2, 1>,
+        device_gemm_trait::S<0, 2, 1>,
+        1,
+        4,    //B1BlockTransferSrcScalarPerVector
+        2,
+        false,
+        1,                                    // CShuffleMXdlPerWavePerShuffle
+        2,        // CShuffleNXdlPerWavePerShuffle
+        device_gemm_trait::S<1, 32, 1, 8>,  // CShuffleBlockTransferClusterLengths_MBlock_MPerBlock_NBlock_NPerBlock
+        8,                                    // CShuffleBlockTransferScalarPerVector_NPerBlock
+        DeviceGemmTraits::kMaskingSpec,                      // MaskingSpecialization
+        DeviceGemmTraits::kIsDeterministic>;
+
 // type alias for DeviceGroupedMultiheadAttentionForward_Xdl_CShuffle with head_dim = 128
 template <typename DeviceGemmTraits>
 using DeviceGemmQLoopHeadDim128 = device_op::DeviceGroupedMultiheadAttentionForward_Xdl_CShuffle_V2<

--- a/csrc/flash_attn_rocm/src/launch_params.h
+++ b/csrc/flash_attn_rocm/src/launch_params.h
@@ -115,6 +115,7 @@ struct FlashFwdParams : public QkvParams {
   bool is_performance_mode;
   bool is_deterministic;
   bool is_using_qloop;
+  bool is_mnko_padding;
 };
 
 struct FlashBwdParams : public FlashFwdParams {


### PR DESCRIPTION
Added non padding conditions and non dropout conditions to improve performance.
Now the perfmorance can reach up to 70TFLOPS in unpadding conditions.
<html xmlns:m="http://schemas.microsoft.com/office/2004/12/omml"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=PowerPoint.Slide>
<meta name=Generator content="Microsoft PowerPoint 15">
<style>
<!--tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
td
	{padding-top:1.0px;
	padding-right:1.0px;
	padding-left:1.0px;
	mso-ignore:padding;
	color:windowtext;
	font-size:18.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Arial;
	mso-generic-font-family:auto;
	mso-font-charset:0;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;}
.oa1
	{border:1.0pt solid white;
	background:lightgrey;
	mso-pattern:auto none;
	text-align:center;
	vertical-align:middle;
	padding-left:.37pt;
	padding-top:.37pt;
	padding-right:.37pt;}
.oa2
	{border:1.0pt solid white;
	background:#EAEAEA;
	mso-pattern:auto none;
	text-align:center;
	vertical-align:middle;
	padding-left:.37pt;
	padding-top:.37pt;
	padding-right:.37pt;}
-->
</style>
</head>

<body>
<!--StartFragment-->



  |   |   |   |   |   |   |   | previous | now | previous | now | improvement   of TFLOPS
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
dtype | batch   size | embedding   size | nheads | embedding   dim | seqlen | casual | dropout | mi250   fwd(ms) | mi250   fwd(ms) | TFLOPS/mi250 | TFLOPS/mi250 | (now/previous)-1
torch.float16 | 32 | 2048 | 16 | 128 | 512 | True | 0 | 1.48 | 1.28 | 23.21603944 | 26.8435456 | 0.15625
torch.float16 | 32 | 2048 | 16 | 128 | 512 | False | 0 | 1.5 | 1.26 | 45.81298449 | 54.53926725 | 0.19047619
torch.float16 | 16 | 2048 | 16 | 128 | 1024 | True | 0 | 2.47 | 2.21 | 27.8216505 | 31.09478585 | 0.117647059
torch.float16 | 16 | 2048 | 16 | 128 | 1024 | False | 0 | 2.52 | 2.09 | 54.53926725 | 65.76026482 | 0.205741627
torch.float16 | 8 | 2048 | 16 | 128 | 2048 | True | 0 | 3.6 | 3.06 | 38.17748708 | 44.91469068 | 0.176470588
torch.float16 | 8 | 2048 | 16 | 128 | 2048 | False | 0 | 4.63 | 3.81 | 59.36887839 | 72.14643227 | 0.215223097
torch.float16 | 4 | 2048 | 16 | 128 | 4096 | True | 0 | 5.93 | 5.06 | 46.35377857 | 54.32369702 | 0.171936759
torch.float16 | 4 | 2048 | 16 | 128 | 4096 | False | 0 | 8.97 | 7.29 | 61.28827357 | 75.41232015 | 0.230452675
torch.float16 | 2 | 2048 | 16 | 128 | 8192 | True | 0 | 10.65 | 9.13 | 51.62026421 | 60.21421839 | 0.166484118
torch.float16 | 2 | 2048 | 16 | 128 | 8192 | False | 0 | 17.8 | 14.31 | 61.77031617 | 76.83519411 | 0.243885395
torch.float16 | 1 | 2048 | 16 | 128 | 16384 | True | 0 | 20.33 | 17.36 | 54.08320845 | 63.33592326 | 0.171082949
torch.float16 | 1 | 2048 | 16 | 128 | 16384 | False | 0 | 35.54 | 28.53 | 61.8745992 | 77.07757643 | 0.245706274
torch.float16 | 32 | 2048 | 32 | 64 | 512 | True | 0 | 1.47 | 1.33 | 23.37397168 | 25.83438975 | 0.105263158
torch.float16 | 32 | 2048 | 32 | 64 | 512 | False | 0 | 1.47 | 1.24 | 46.74794336 | 55.41893285 | 0.185483871
torch.float16 | 16 | 2048 | 32 | 64 | 1024 | True | 0 | 2.45 | 2.21 | 28.04876601 | 31.09478585 | 0.108597285
torch.float16 | 16 | 2048 | 32 | 64 | 1024 | False | 0 | 2.53 | 2.00 | 54.32369702 | 68.71947674 | 0.265
torch.float16 | 8 | 2048 | 32 | 64 | 2048 | True | 0 | 3.59 | 3.16 | 38.28383105 | 43.49333971 | 0.136075949
torch.float16 | 8 | 2048 | 32 | 64 | 2048 | False | 0 | 4.75 | 3.76 | 57.86903304 | 73.10582631 | 0.263297872
torch.float16 | 4 | 2048 | 32 | 64 | 4096 | True | 0 | 5.96 | 5.23 | 46.12045419 | 52.5579172 | 0.13957935
torch.float16 | 4 | 2048 | 32 | 64 | 4096 | False | 0 | 9.26 | 7.26 | 59.36887839 | 75.72394131 | 0.275482094
torch.float16 | 2 | 2048 | 32 | 64 | 8192 | True | 0 | 10.69 | 9.38 | 51.42711075 | 58.60936182 | 0.139658849
torch.float16 | 2 | 2048 | 32 | 64 | 8192 | False | 0 | 18.29 | 14.32 | 60.11545258 | 76.78153825 | 0.277234637
torch.float16 | 1 | 2048 | 32 | 64 | 16384 | True | 0 | 20.27 | 17.82 | 54.24329688 | 61.70098921 | 0.137485971
torch.float16 | 1 | 2048 | 32 | 64 | 16384 | False | 0 | 36.44 | 28.58 | 60.34641206 | 76.94273112 | 0.275017495



<!--EndFragment-->
</body>

</html>
