### PR TITLE
Remove offload-arch=native in the build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -207,7 +207,6 @@ if not IS_ROCM_PYTORCH:
 else:
 # build for ROCm
   cc_flag = []
-  cc_flag.append("--offload-arch=native")
                         
   if int(os.environ.get('FLASH_ATTENTION_INTERNAL_USE_RTN', 0)):
     print("RTN IS USED")


### PR DESCRIPTION
Hi,

Hard-coding `--offload-arch=native` make the build of RoCm flash attention fail in docker build (as I guess GPUs are not accessible during build)

Moreover, this prevents `setup.py` to obey to the variable [`PYTORCH_ROCM_ARCH`](https://github.com/pytorch/pytorch/blob/185515368bcd7d94ac06ab1634f22b747b03c6d9/setup.py#L141), which is a quite useful feature.